### PR TITLE
Validate list of dependencies prior to constructing package_map

### DIFF
--- a/R/dash.R
+++ b/R/dash.R
@@ -569,7 +569,7 @@ Dash <- R6::R6Class(
         dep$stylesheet <- NULL
         dep
       }))
-
+      
       private$.index <- sprintf(
         '<!DOCTYPE html>
         <html>

--- a/R/dash.R
+++ b/R/dash.R
@@ -289,7 +289,7 @@ Dash <- R6::R6Class(
  
         dep_pkg <- get_package_mapping(filename, 
                                        keys$package_name,
-                                       assert_valid_dependencies(dep_list) 
+                                       clean_dependencies(dep_list) 
                                        )
 
         dep_path <- system.file(dep_pkg$rpkg_path, 

--- a/R/dash.R
+++ b/R/dash.R
@@ -282,12 +282,14 @@ Dash <- R6::R6Class(
       dash_suite <- paste0(self$config$routes_pathname_prefix, "_dash-component-suites/:package_name/:filename")
       route$add_handler("get", dash_suite, function(request, response, keys, ...) {
         filename <- basename(file.path(keys$filename))
-        
+
+        dep_list <- c(private$dependencies_internal,
+                      private$dependencies,
+                      private$dependencies_user)       
+ 
         dep_pkg <- get_package_mapping(filename, 
                                        keys$package_name,
-                                       c(private$dependencies_internal,
-                                                    private$dependencies,
-                                                    private$dependencies_user)
+                                       assert_valid_dependencies(dep_list) 
                                        )
 
         dep_path <- system.file(dep_pkg$rpkg_path, 

--- a/R/utils.R
+++ b/R/utils.R
@@ -176,7 +176,7 @@ render_dependencies <- function(dependencies, local = TRUE, prefix=NULL) {
     # until we are able to provide full support for debug mode,
     # as in Dash for Python
     if ("script" %in% names(dep) && tools::file_ext(dep[["script"]]) != "map") {
-      if !(is.null(dep$src$href)) {
+      if (!(is.null(dep$src$href))) {
         html <- sprintf("<script src=\"%s\"></script>", dep$src$href)
       } else {
         dep[["script"]] <- paste0(prefix,

--- a/R/utils.R
+++ b/R/utils.R
@@ -163,7 +163,6 @@ render_dependencies <- function(dependencies, local = TRUE, prefix=NULL) {
       dep_path <- gsub("//+",
                        "/",
                        dep_path)
-      )
       
       full_path <- system.file(dep_path,
                                package = dep$package)
@@ -177,13 +176,17 @@ render_dependencies <- function(dependencies, local = TRUE, prefix=NULL) {
     # until we are able to provide full support for debug mode,
     # as in Dash for Python
     if ("script" %in% names(dep) && tools::file_ext(dep[["script"]]) != "map") {
-      dep[["script"]] <- paste0(prefix,
-                                "_dash-component-suites/",
-                                dep$name,
-                                "/",
-                                basename(dep[["script"]]),
-                                sprintf("?v=%s&m=%s", dep$version, modified))
-      html <- sprintf("<script src=\"%s\"></script>", dep[["script"]])
+      if !(is.null(dep$src$href)) {
+        html <- sprintf("<script src=\"%s\"></script>", dep$src$href)
+      } else {
+        dep[["script"]] <- paste0(prefix,
+                                  "_dash-component-suites/",
+                                  dep$name,
+                                  "/",
+                                  basename(dep[["script"]]),
+                                  sprintf("?v=%s&m=%s", dep$version, modified))
+        html <- sprintf("<script src=\"%s\"></script>", dep[["script"]])
+      }
     } else if ("stylesheet" %in% names(dep) & src == "href") {
       html <- sprintf("<link href=\"%s\" rel=\"stylesheet\" />", paste(dep[["src"]][["href"]],
                                                                        dep[["stylesheet"]], 

--- a/R/utils.R
+++ b/R/utils.R
@@ -321,8 +321,12 @@ filter_null <- function(x) {
 # filtered out by the subsequent vapply statement
 assert_valid_dependencies <- function(deps) {
   dep_list <- lapply(deps, function(x) {
-    if (is.null(x$src$file) | is.null(x$script) | (is.null(x$package)))
-      return(NULL)
+    if (is.null(x$src$file) | is.null(x$script) | (is.null(x$package))) {
+      if (is.null(x$stylesheet) & is.null(x$src$href))
+        stop(sprintf("Script dependencies with NULL href fields must include a file path, script name, and R package name."), call. = FALSE)
+      else
+        return(NULL)
+    }
     else
       return(x)
     }

--- a/R/utils.R
+++ b/R/utils.R
@@ -189,8 +189,15 @@ render_dependencies <- function(dependencies, local = TRUE, prefix=NULL) {
                                                                        dep[["stylesheet"]], 
                                                                        sep="/"))
     } else if ("stylesheet" %in% names(dep) & src == "file") {
-      html <- sprintf("<link href=\"%s\" rel=\"stylesheet\" />", file.path(dep[["src"]][["file"]], 
-                                                                           dep[["stylesheet"]]))
+      if (!(is.null(dep$version))) {
+        html <- sprintf("<link href=\"%s?v=%s\" rel=\"stylesheet\" />", file.path(dep[["src"]][["file"]],
+                                                                                  dep[["stylesheet"]]),
+                        dep$version)        
+      } else {
+        html <- sprintf("<link href=\"%s\" rel=\"stylesheet\" />", file.path(dep[["src"]][["file"]],
+                                                                             dep[["stylesheet"]])
+        )
+      }
     }
   })
   paste(html, collapse = "\n")

--- a/R/utils.R
+++ b/R/utils.R
@@ -119,10 +119,16 @@ render_dependencies <- function(dependencies, local = TRUE, prefix=NULL) {
     assertthat::assert_that(inherits(dep, "html_dependency"))
     srcs <- names(dep[["src"]])
     src <- if (!local && !"href" %in% srcs && "file" %in% srcs) {
-      message("No remote hyperlink found for HTML dependency '", dep[["name"]], "'. Using local file instead.")
+      msg <- paste0("No remote hyperlink found for HTML dependency ",
+                    dep[["name"]],
+                    ". Using local file instead.")
+      message(msg)
       "file"
     } else if (local && !"file" %in% srcs && "href" %in% srcs) {
-      message("No local file found for HTML dependency '", dep[["name"]], "'. Using the remote hyperlink instead.")
+      msg <- paste0("No local file found for HTML dependency ",
+                    dep[["name"]],
+                    ". Using the remote URL instead.")
+      message(msg)
       "href"
     } else if (!local) {
       "href"

--- a/R/utils.R
+++ b/R/utils.R
@@ -322,7 +322,7 @@ filter_null <- function(x) {
 # within get_package_mapping, x$package is also required,
 # so deps missing it here are assigned NULL and then
 # filtered out by the subsequent vapply statement
-assert_valid_dependencies <- function(deps) {
+clean_dependencies <- function(deps) {
   dep_list <- lapply(deps, function(x) {
     if (is.null(x$src$file) | is.null(x$script) | (is.null(x$package))) {
       if (is.null(x$stylesheet) & is.null(x$src$href))

--- a/R/utils.R
+++ b/R/utils.R
@@ -292,6 +292,33 @@ filter_null <- function(x) {
   x[!vapply(x, is.null, logical(1))]
 }
 
+# the following function attempts to prune remote CSS
+# or local CSS/JS dependencies that either should not
+# be resolved to local R package paths, or which have
+# insufficient information to do so. 
+#
+# this attempts to avoid cryptic errors produced by
+# get_package_mapping, which requires three parameters:
+# -- the script name (i.e. x$script below)
+# -- the package name from the URL (i.e. x$package)
+# -- the list of dependencies (i.e. deps)
+#
+# within get_package_mapping, x$package is also required,
+# so deps missing it here are assigned NULL and then
+# filtered out by the subsequent vapply statement
+assert_valid_dependencies <- function(deps) {
+  dep_list <- lapply(deps, function(x) {
+    if (is.null(x$src$file) | is.null(x$script) | (is.null(x$package)))
+      return(NULL)
+    else
+      return(x)
+    }
+  )
+  deps_with_file <- dep_list[!vapply(dep_list, is.null, logical(1))]
+  
+  return(deps_with_file)
+}
+
 assert_valid_callbacks <- function(output, params, func) {
   inputs <- params[vapply(params, function(x) 'input' %in% attr(x, "class"), FUN.VALUE=logical(1))]
   state <- params[vapply(params, function(x) 'state' %in% attr(x, "class"), FUN.VALUE=logical(1))]


### PR DESCRIPTION
This PR proposes introducing a function called `clean_dependencies` to help ensure that the list of dependencies passed to `get_package_mapping` contains no elements which are missing one or more of the following:
- a dependency name
- the dependency "package" name from the URL (which is generally ≠ to the R package name)
- a list of dependencies in `htmltools` format
- the R package name, registered within each element of the dependency list described above

Closes https://github.com/plotly/dashR/issues/56.