### PR TITLE
Support json args

### DIFF
--- a/R/dash.R
+++ b/R/dash.R
@@ -254,7 +254,7 @@ Dash <- R6::R6Class(
           if(is.null(input_element$value))
             callback_args <- c(callback_args, list(list(NULL)))
           else
-            callback_args <- c(callback_args, input_element$value)
+            callback_args <- c(callback_args, list(input_element$value))
         }
         
         if (length(request$body$state)) {
@@ -262,7 +262,7 @@ Dash <- R6::R6Class(
             if(is.null(state_element$value))
               callback_args <- c(callback_args, list(list(NULL)))
             else
-              callback_args <- c(callback_args, state_element$value)
+              callback_args <- c(callback_args, list(state_element$value))
           }
         }
                 

--- a/R/dash.R
+++ b/R/dash.R
@@ -138,7 +138,7 @@ Dash <- R6::R6Class(
       self$config$routes_pathname_prefix <- resolve_prefix(routes_pathname_prefix, "DASH_ROUTES_PATHNAME_PREFIX")
       self$config$requests_pathname_prefix <- resolve_prefix(requests_pathname_prefix, "DASH_REQUESTS_PATHNAME_PREFIX")
       self$config$external_stylesheets <- external_stylesheets
- 
+
       # produce a true copy of the fiery server, since we don't want our
       # attachments/modifications having unintended side-effects
       # https://github.com/thomasp85/fiery/issues/30
@@ -249,14 +249,14 @@ Dash <- R6::R6Class(
         #
         # https://cran.r-project.org/doc/FAQ/R-FAQ.html#Others:
         callback_args <- list()
-        
+
         for (input_element in request$body$inputs) {
           if(is.null(input_element$value))
             callback_args <- c(callback_args, list(list(NULL)))
           else
             callback_args <- c(callback_args, list(input_element$value))
         }
-        
+
         if (length(request$body$state)) {
           for (state_element in request$body$state) {
             if(is.null(state_element$value))
@@ -265,7 +265,7 @@ Dash <- R6::R6Class(
               callback_args <- c(callback_args, list(state_element$value))
           }
         }
-                
+
         output_value <- do.call(callback, callback_args)
 
         # have to format the response body like this
@@ -282,7 +282,7 @@ Dash <- R6::R6Class(
         TRUE
       })
 
-      # This endpoint supports dynamic dependency loading 
+      # This endpoint supports dynamic dependency loading
       # during `_dash-update-component` -- for reference:
       # https://github.com/plotly/dash/blob/1249ffbd051bfb5fdbe439612cbec7fa8fff5ab5/dash/dash.py#L488
       # https://docs.python.org/3/library/pkgutil.html#pkgutil.get_data
@@ -292,22 +292,22 @@ Dash <- R6::R6Class(
 
         dep_list <- c(private$dependencies_internal,
                       private$dependencies,
-                      private$dependencies_user)       
- 
-        dep_pkg <- get_package_mapping(filename, 
+                      private$dependencies_user)
+
+        dep_pkg <- get_package_mapping(filename,
                                        keys$package_name,
-                                       clean_dependencies(dep_list) 
+                                       clean_dependencies(dep_list)
                                        )
 
-        dep_path <- system.file(dep_pkg$rpkg_path, 
+        dep_path <- system.file(dep_pkg$rpkg_path,
                                 package = dep_pkg$rpkg_name)
 
         response$body <- readLines(dep_path,
-                                   warn = FALSE, 
+                                   warn = FALSE,
                                    encoding = "UTF-8")
         response$status <- 200L
-        response$set_header('Cache-Control', 
-                            sprintf('public, max-age=%s', 
+        response$set_header('Cache-Control',
+                            sprintf('public, max-age=%s',
                                     components_cache_max_age)
                             )
         response$type <- get_mimetype(filename)
@@ -580,7 +580,7 @@ Dash <- R6::R6Class(
       css <- paste(c(vapply(self$config$external_stylesheets, generate_css_dist_html, FUN.VALUE=character(1)),
                      render_dependencies(depsCSS, local = private$serve_locally, prefix=self$config$requests_pathname_prefix)),
                    collapse="\n")
-      
+
       private$.index <- sprintf(
         '<!DOCTYPE html>
         <html>
@@ -606,7 +606,7 @@ Dash <- R6::R6Class(
         to_JSON(self$config),
         render_dependencies(depsScripts, local = private$serve_locally, prefix=self$config$requests_pathname_prefix)
       )
-      
+
     }
   )
 )


### PR DESCRIPTION
Fixes #61 - the problem was that `do.call` was interpreting the keys of JSON objects as named args to the callback, just needed to wrap in a `list` to avoid this. @rpkyle as I'm a total R noob please ensure this makes sense!

Seems to work with the rest of dashR docs as they stand ATM, tested the error @TahiriNadia  encountered in #61 using this test app:

```R
library(jsonlite)

library(dashR)
library(dashCoreComponents)
library(dashHtmlComponents)

 app <- Dash$new()

 app$layout_set(
  htmlDiv(list(
    htmlH1('Hello Dash'),
    htmlDiv(id='a', children="Dash: A web application framework for R."),
    dccGraph(figure=list(
      data=list(
        list(
          x=list(1, 2, 3),
          y=list(4, 1, 2),
          type='bar',
          name='SF'
        ),
        list(
          x=list(1, 2, 3),
          y=list(2, 4, 5),
          type='bar',
          name='Montréal'
        )
      ),
      layout=list(title='Dash Data Visualization')
    ),
    id='b'
    )
  ))
)

app$callback(output('a', 'children'), list(input('b', 'hoverData')),
  function(hoverData) {
      toJSON(hoverData)
  }
)

app$run_server()
```