### PR TITLE
Display a useful warning message and return HTTP 404 when dependency not found

### DIFF
--- a/R/dash.R
+++ b/R/dash.R
@@ -296,18 +296,31 @@ Dash <- R6::R6Class(
                                        clean_dependencies(dep_list)
                                        )
 
-        dep_path <- system.file(dep_pkg$rpkg_path,
-                                package = dep_pkg$rpkg_name)
 
-        response$body <- readLines(dep_path,
-                                   warn = FALSE,
-                                   encoding = "UTF-8")
-        response$status <- 200L
-        response$set_header('Cache-Control',
-                            sprintf('public, max-age=%s',
-                                    components_cache_max_age)
-                            )
-        response$type <- get_mimetype(filename)
+        # return warning if a dependency goes unmatched, since the page
+        # will probably fail to render properly anyway without it
+        if (length(dep_pkg$rpkg_path) == 0) {
+          warning(sprintf("The dependency '%s' could not be loaded; the file was not found.", 
+                          filename), 
+                  call. = FALSE)
+          
+          response$body <- NULL
+          response$status <- 404L
+        } else {
+          dep_path <- system.file(dep_pkg$rpkg_path,
+                                  package = dep_pkg$rpkg_name)
+          
+          response$body <- readLines(dep_path,
+                                     warn = FALSE,
+                                     encoding = "UTF-8")
+          response$status <- 200L
+          response$set_header('Cache-Control',
+                              sprintf('public, max-age=%s',
+                                      components_cache_max_age)
+                              )
+          response$type <- get_mimetype(filename)
+        }
+
         TRUE
       })
 


### PR DESCRIPTION
Following on comments from @KPhans, this PR proposes to
- present a `warning` message if a filename from the `request$url` object is not located in the `package_map`; this implies that the dependency requested could not be found
- include the filename of the requested dependency in the `warning`
- return HTTP 404 instead of HTTP 200

Previously, unmatched dependencies would trigger a cryptic `'package' must be of length 1` error, which was not helpful for end users or developers attempting to debug such errors.

Closes https://github.com/plotly/dashR/issues/79.