### PR TITLE
Add support for 'subplots' from plot_ly and ggplotly in DashR

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -577,8 +577,9 @@ get_asset_url <- function(asset_path, prefix = "/") {
                               
 encode_plotly <- function(layout_objs) {
   if (is.list(layout_objs)) {
-    if ("x" %in% names(layout_objs) &&
-        "visdat" %in% names(layout_objs$x)) {
+    if ("plotly" %in% class(layout_objs) &&
+        "x" %in% names(layout_objs) &&
+        any(names(layout_objs$x) == c("visdat", "data"))) {
       # check to determine whether the current element is an
       # object output from the plot_ly or ggplotly function;
       # if it is, we can safely assume that it contains no 

--- a/R/utils.R
+++ b/R/utils.R
@@ -579,7 +579,7 @@ encode_plotly <- function(layout_objs) {
   if (is.list(layout_objs)) {
     if ("plotly" %in% class(layout_objs) &&
         "x" %in% names(layout_objs) &&
-        any(names(layout_objs$x) == c("visdat", "data"))) {
+        any(c("visdat", "data") %in% names(layout_objs$x))) {
       # check to determine whether the current element is an
       # object output from the plot_ly or ggplotly function;
       # if it is, we can safely assume that it contains no 


### PR DESCRIPTION
As pointed out by @sacul-git in https://github.com/plotly/dashR/issues/83, DashR would fail to properly mutate `plot_ly` and `ggplotly` objects constructed using the `subplots` function from the `plotly` R package.

The changes proposed in this PR change the logic for mutating the layout in `encode_plotly`; now, the function will
- introspect the object to check to see if it is a `list`; if it is, then
- check to see if the object class attributes include `plotly`; if they do, then
- check to see if the list contains a named element `x`; if it does, then
- check to see if any names within `x` match `visdat` or `data`; if they do, mutate

https://github.com/plotly/dashR/blob/5264c7ca3d52fd8ef5cc5ef28d5ac18f5fbf705a/R/utils.R#L579-L582