### PR TITLE
Crawl package namespaces for CSS/JS deps metadata

### DIFF
--- a/R/dash.R
+++ b/R/dash.R
@@ -594,9 +594,11 @@ Dash <- R6::R6Class(
         )
       }
 
-      # load package-level HTML dependencies
-      pkgs <- unique(layout_flat[grepl("package$", layout_nms)])
-      deps_layout <- lapply(pkgs, function(pkg) {
+      # load package-level HTML dependencies from attached pkgs
+      metadataFns <- lapply(.packages(), getDashMetadata)
+      metadataFns <- metadataFns[lengths(metadataFns) != 0]
+      
+      deps_layout <- lapply(metadataFns, function(dep) {
         # the objective is to identify JS dependencies
         # without requiring that a proprietary R format
         # file is loaded at object initialization to
@@ -612,8 +614,7 @@ Dash <- R6::R6Class(
         # elegant.
         #
         # construct function name based on package name
-        fn_name <- paste0(".", pkg, "_js_metadata")
-        fn_summary <- getAnywhere(fn_name)
+        fn_summary <- getAnywhere(dep)
 
         # ensure that the object refers to a function,
         # and we are able to locate it somewhere

--- a/R/dash.R
+++ b/R/dash.R
@@ -758,9 +758,9 @@ Dash <- R6::R6Class(
     .index = NULL,
     
     collect_resources = function() {
-      # DashR's own dependencies
+      # Dash's own dependencies
       # serve the dev version of dash-renderer when in debug mode
-      dependencies_all_internal <- dashR:::.dashR_js_metadata()
+      dependencies_all_internal <- dash:::.dash_js_metadata()
       if (private$debug) {
         depsSubset <- dependencies_all_internal[names(dependencies_all_internal) != c("dash-renderer-prod",
                                                                                       "dash-renderer-map-prod")]

--- a/R/internal.R
+++ b/R/internal.R
@@ -1,4 +1,4 @@
-.dashR_js_metadata <- function() {
+.dash_js_metadata <- function() {
   deps_metadata <- list(`react-prod` = structure(list(name = "react",
                                                       version = "16.8.6",
                                                       src = list(href = "https://unpkg.com/react@16.8.6",

--- a/R/utils.R
+++ b/R/utils.R
@@ -161,7 +161,7 @@ render_dependencies <- function(dependencies, local = TRUE, prefix=NULL) {
         filename <- dep$stylesheet
       }
       
-      dep_path <- paste0(dep$src$file, filename)
+      dep_path <- paste(dep$src$file, filename, sep="/")
       
       # the gsub line is to remove stray duplicate slashes, to
       # permit exact string matching on pathnames

--- a/R/utils.R
+++ b/R/utils.R
@@ -838,3 +838,11 @@ setCallbackContext <- function(callback_elements) {
               triggered=unlist(triggered, recursive=FALSE), 
               inputs=inputs))
 }
+
+
+getDashMetadata <- function(pkgname) {
+  fnList <- ls(getNamespace(pkgname), all.names = TRUE)
+  metadataFn <- as.vector(fnList[grepl("^\\.dash([[:alpha:]]).*_js_metadata$", fnList)])
+  return(metadataFn)
+}
+

--- a/R/utils.R
+++ b/R/utils.R
@@ -839,10 +839,8 @@ setCallbackContext <- function(callback_elements) {
               inputs=inputs))
 }
 
-
 getDashMetadata <- function(pkgname) {
   fnList <- ls(getNamespace(pkgname), all.names = TRUE)
-  metadataFn <- as.vector(fnList[grepl("^\\.dash([[:alpha:]]).*_js_metadata$", fnList)])
+  metadataFn <- as.vector(fnList[grepl("^\\.dash.+_js_metadata$", fnList)])
   return(metadataFn)
 }
-


### PR DESCRIPTION
As originally noted in #50, the current strategy of crawling the Dash layout to identify packages that supply CSS and JavaScript dependencies is potentially problematic. 

If the initial layout does not contain any components from a given library, their associated assets will not be loaded. This PR proposes to modify the dependency resolution process somewhat:
- retrieve the namespace information for each currently attached (loaded) package
- subset the list of objects using regex such that only functions whose name matches `.dash*_js_metadata` are retained (this omits the Dash for R internal metadata, to prevent loading these assets twice)
- as before, retrieve the contents of the metadata function and append to the dependency list for loading

Thanks to @sacul-git for reporting the initial manifestation of this issue, and for supplying a reproducible example for testing purposes.

Closes #50.

@alexcjohnson @chriddyp 