### PR TITLE
Remove welcome_page() and layout_container_id()

### DIFF
--- a/R/dash.R
+++ b/R/dash.R
@@ -445,7 +445,7 @@ Dash <- R6::R6Class(
       if (render) private$layout_render() else private$layout_
     },
     layout = function(...) {
-      private$layout_ <- if (is.function(..1)) ..1 else list(...)
+      private$layout_ <- if (is.function(..1)) ..1 else (...) 
       # render the layout, and then return the rendered layout without printing
       invisible(private$layout_render())
     },
@@ -560,16 +560,8 @@ Dash <- R6::R6Class(
       # assuming private$layout is either a function or a list of components...
       layout_ <- if (is.function(private$layout_)) private$layout_() else private$layout_
 
-      # accomodate functions that return a single component
-      if (is.component(layout_)) layout_ <- list(layout_)
-
-      # make sure we are working with a list of components
-      layout_ <- lapply(layout_, private$componentify)
-
-      # Put the list of components into a container div. I'm pretty sure dash
-      # requires the layout to be one component, but R folks are used to
-      # being able to supply "components" to ...
-      layout_ <- dashHtmlComponents::htmlDiv(children = layout_, id = layout_container_id())
+      # ensure layout is a Dash component or collection of components
+      layout_ <- private$validate_component(layout_)
 
       # store the layout as a (flattened) vector form since we query the
       # vector names several times to verify ID naming (among other things)
@@ -731,7 +723,7 @@ Dash <- R6::R6Class(
                   other = other_files_map))
     },
 
-    componentify = function(x) {
+    validate_component = function(x) {
       if (is.component(x)) return(x)
       if (all(vapply(x, is.component, logical(1)))) return(x)
       stop("The layout must be a component or a collection of components", call. = FALSE)

--- a/R/dash.R
+++ b/R/dash.R
@@ -912,7 +912,7 @@ Dash <- R6::R6Class(
 # @param layout
 # @param component a component (should be a dependency)
 validate_dependency <- function(layout_, dependency) {
-  if (!is.layout(layout_)) stop("`layout` must be a dash layout object", call. = FALSE)
+  if (!is.component(layout_)) stop("`layout` must be a Dash component or collection of components", call. = FALSE)
   if (!is.dependency(dependency)) stop("`dependency` must be a dash dependency object", call. = FALSE)
 
   valid_props <- component_props_given_id(layout, dependency$id)

--- a/R/dash.R
+++ b/R/dash.R
@@ -554,7 +554,7 @@ Dash <- R6::R6Class(
     dependencies_internal = list(),
 
     # layout stuff
-    layout_ = welcome_page(),
+    layout_ = NULL,
     layout_ids = NULL,
     layout_render = function() {
       # assuming private$layout is either a function or a list of components...

--- a/R/utils.R
+++ b/R/utils.R
@@ -265,13 +265,6 @@ setdiffsym <- function(x, y) {
   setdiff(union(x, y), intersect(x, y))
 }
 
-welcome_page <- function() {
-  #dashHtmlComponents::htmlDiv(
-  #  dashHtmlComponents::htmlH2("Welcome to dash!"),
-  #  "If you see this message, you may not have yet specified a layout in your application."
-  #)
-}
-
 stop_report <- function(msg = "") {
   stop(
     msg, "\n\n",

--- a/R/utils.R
+++ b/R/utils.R
@@ -14,15 +14,6 @@ is.state <- function(x) inherits(x, "state")
 # components (TODO: this should be exported by dashRtranspile!)
 is.component <- function(x) inherits(x, "dash_component")
 
-# layout is really a special type of component
-is.layout <- function(x) {
-  is.component(x) && identical(x[["props"]][["id"]], layout_container_id())
-}
-
-layout_container_id <- function() {
-  "_dashR-layout-container"
-}
-
 # retrieve the arguments of a callback function that are dash inputs
 callback_inputs <- function(func) {
   compact(lapply(formals(func), function(x) {


### PR DESCRIPTION
This PR proposes to :hocho: these Dash for R elements, which do not exist in Dash for Python:
- [x] `layout_container_id()`
- [x] `welcome_page()`
- [x] `is.layout()` -- this checked that `is.component()` returned `TRUE`, and that `id == layout_container_id()`

In addition, `componentify()` is renamed to `validate_component()`, which is somewhat clearer.

The primary motivation is to enforce parity with Dash for Python, and to properly expose the layout object to work with layout validation checks which are already in place.

@alexcjohnson 