### PR TITLE
Add GitHub remotes to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,6 +31,9 @@ Collate:
   'imports.R'
   'print.R'
   'internal.R'
+Remotes: plotly/dash-html-components,
+  plotly/dash-core-components,
+  plotly/dash-table
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true


### PR DESCRIPTION
The proposed PR adds remote entries to the package `DESCRIPTION` file for convenience. Installing dependencies out of order should no longer present a barrier to successful Dash for R installs.