### PR TITLE
Add commit tags to Remotes: section

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,9 +31,9 @@ Collate:
   'imports.R'
   'print.R'
   'internal.R'
-Remotes: plotly/dash-html-components,
-  plotly/dash-core-components,
-  plotly/dash-table
+Remotes: plotly/dash-html-components@17da1f4,
+  plotly/dash-core-components@cc1e654,
+  plotly/dash-table@e90fa76
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true


### PR DESCRIPTION
This PR proposes to version-lock the `dash` dependencies by hardcoding commit tags for `dashHtmlComponents`, `dashCoreComponents` and `dashTable`.

In the future, these will be released with version tags for the corresponding repositories.

@alexcjohnson @Marc-Andre-Rivet 