### PR TITLE
Update dashTable version to 4.0.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Depends:
 Imports:
   dashHtmlComponents (== 1.0.0),
   dashCoreComponents (== 1.0.0),
-  dashTable (== 4.0.0),
+  dashTable (== 4.0.2),
   R6,
   fiery (> 1.0.0),
   routr (> 0.2.0),
@@ -33,7 +33,7 @@ Collate:
   'internal.R'
 Remotes: plotly/dash-html-components@17da1f4,
   plotly/dash-core-components@cc1e654,
-  plotly/dash-table@e90fa76
+  plotly/dash-table@042ad65
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true


### PR DESCRIPTION
This PR proposes to require and fetch v4.0.2 of `dashTable`, and updates the commit hash to `042ad65` while bumping the hard version requirement in `DESCRIPTION`.