### PR TITLE
Provide support for no_update in Dash for R

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,6 +2,7 @@
 
 S3method(print,dash_component)
 export(Dash)
+export(dashNoUpdate)
 export(input)
 export(output)
 export(state)

--- a/R/dash.R
+++ b/R/dash.R
@@ -528,7 +528,7 @@ Dash <- R6::R6Class(
     # no_update may be used within a callback to prevent a single output
     # from updating; it returns a wrapped NULL of class "no_update"
     # ------------------------------------------------------------------------
-    no_update <- function() {
+    no_update = function() {
       x <- list(NULL)
       class(x) <- "no_update"
       return(x)

--- a/R/dash.R
+++ b/R/dash.R
@@ -293,7 +293,7 @@ Dash <- R6::R6Class(
  
         # inspect the output_value to determine whether any outputs have no_update
         # objects within them; these should not be updated
-        if (class(output_value) == "no_update") {
+        if (length(output_value) == 1 && class(output_value) == "no_update") {
           response$body <- character(1) # return empty string
           response$status <- 204L
         }

--- a/R/dash.R
+++ b/R/dash.R
@@ -287,7 +287,7 @@ Dash <- R6::R6Class(
         output_value <- getStackTrace(do.call(callback, callback_args),
                                       debug = private$debug,
                                       pruned_errors = private$pruned_errors)
-        
+
         # reset callback context
         private$callback_context_ <- NULL
  

--- a/R/dash.R
+++ b/R/dash.R
@@ -525,16 +525,6 @@ Dash <- R6::R6Class(
     },
     
     # ------------------------------------------------------------------------
-    # no_update may be used within a callback to prevent a single output
-    # from updating; it returns a wrapped NULL of class "no_update"
-    # ------------------------------------------------------------------------
-    no_update = function() {
-      x <- list(NULL)
-      class(x) <- "no_update"
-      return(x)
-    },
-    
-    # ------------------------------------------------------------------------
     # convenient fiery wrappers
     # ------------------------------------------------------------------------
     run_server = function(host = Sys.getenv('DASH_HOST', "127.0.0.1"), 

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -5,10 +5,14 @@
 #' Use in conjunction with the `callback()` method from the [dash::Dash] class
 #' to define the update logic in your application.
 #'
+#' The `dashNoUpdate()` function permits application developers to prevent a
+#' single output from updating the layout. It has no formal arguments, but
+#' returns an object of class `no_update`, for which Dash will return a `204`
+#' status code and empty response body.
+#' 
 #' @name dependencies
 #' @param id a component id
 #' @param property the component property to use
-
 
 #' @rdname dependencies
 #' @export
@@ -43,4 +47,12 @@ dependency <- function(id = NULL, property = NULL) {
     id = id,
     property = property
   )
+}
+
+#' @rdname dependencies
+#' @export
+dashNoUpdate <- function() {
+  x <- list(NULL)
+  class(x) <- "no_update"
+  return(x)
 }

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -6,9 +6,7 @@
 #' to define the update logic in your application.
 #'
 #' The `dashNoUpdate()` function permits application developers to prevent a
-#' single output from updating the layout. It has no formal arguments, but
-#' returns an object of class `no_update`, for which Dash will return a `204`
-#' status code and empty response body.
+#' single output from updating the layout. It has no formal arguments.
 #' 
 #' @name dependencies
 #' @param id a component id

--- a/man/dependencies.Rd
+++ b/man/dependencies.Rd
@@ -5,6 +5,7 @@
 \alias{output}
 \alias{input}
 \alias{state}
+\alias{dashNoUpdate}
 \title{Input/Output/State definitions}
 \usage{
 output(id, property)
@@ -12,6 +13,8 @@ output(id, property)
 input(id, property)
 
 state(id, property)
+
+dashNoUpdate()
 }
 \arguments{
 \item{id}{a component id}
@@ -21,4 +24,10 @@ state(id, property)
 \description{
 Use in conjunction with the \code{callback()} method from the \link[dash:Dash]{dash::Dash} class
 to define the update logic in your application.
+}
+\details{
+The \code{dashNoUpdate()} function permits application developers to prevent a
+single output from updating the layout. It has no formal arguments, but
+returns an object of class \code{no_update}, for which Dash will return a \code{204}
+status code and empty response body.
 }

--- a/man/dependencies.Rd
+++ b/man/dependencies.Rd
@@ -27,7 +27,5 @@ to define the update logic in your application.
 }
 \details{
 The \code{dashNoUpdate()} function permits application developers to prevent a
-single output from updating the layout. It has no formal arguments, but
-returns an object of class \code{no_update}, for which Dash will return a \code{204}
-status code and empty response body.
+single output from updating the layout. It has no formal arguments.
 }

--- a/tests/integration/callbacks/test_no_update.py
+++ b/tests/integration/callbacks/test_no_update.py
@@ -68,7 +68,7 @@ app$callback(output=list(id='message-box', property='children'),
              }
 )
 
-app$run_server(component_cache_max_age=0)
+app$run_server()
 """
 
 

--- a/tests/integration/callbacks/test_no_update.py
+++ b/tests/integration/callbacks/test_no_update.py
@@ -1,4 +1,5 @@
 from selenium.webdriver.support.select import Select
+import time
 
 app = """
 library(dash)
@@ -16,10 +17,40 @@ app$layout(
       list(label = "Do nothing", value = "nothing")
     ),
     id = "color-selector"),
+    htmlButton(children = "Select all the colors!",
+               id = "multi-selector"
+               ),
     htmlDiv(id='message-box',
-            children='Please select a colour choice from the dropdown menu.')
+            children='Please select a color choice from the dropdown menu.'),
+    htmlDiv(id='message-box2',
+            children=' ')
   )
   )
+)
+
+app$callback(output=list(id='message-box2', property='children'),
+             params=list(
+               input(id='multi-selector', property='n_clicks')),
+             function(n_clicks)
+             {
+               # if button has been clicked, n_clicks is numeric()
+               # on first launch of callback at layout initialization,
+               # value of n_clicks will be list(NULL), which is not
+               # comparable using >, < or =; hence the is.numeric()
+               # check
+               if (is.numeric(n_clicks) && n_clicks >= 1)
+               {
+                 # return a vector to ensure that the check for
+                 # class(x) == "no_update" isn't made for objects
+                 # where length(x) > 1
+                 return(c("Multiple color values: ", 
+                          "#FF0000, ", 
+                          "#00FF00, ", 
+                          "#0000FF ", 
+                          "returned!")
+                        )
+               }
+             }
 )
 
 app$callback(output=list(id='message-box', property='children'),
@@ -28,7 +59,7 @@ app$callback(output=list(id='message-box', property='children'),
              function(color)
              {
                if (color %in% c("#FF0000", "#00FF00", "#0000FF")) {
-                 msg <- sprintf("The hexadecimal representation of your last chosen colour is %s",
+                 msg <- sprintf("The hexadecimal representation of your last chosen color is %s",
                                 color)
                  return(msg)
                } else {
@@ -37,7 +68,7 @@ app$callback(output=list(id='message-box', property='children'),
              }
 )
 
-app$run_server()
+app$run_server(component_cache_max_age=0)
 """
 
 
@@ -45,19 +76,28 @@ def test_rsnu001_no_update(dashr):
     dashr.start_server(app)
     dashr.find_element("#color-selector").click()
     dashr.find_elements("div.VirtualizedSelectOption")[0].click()
-    assert dashr.find_element("#message-box").text == "The hexadecimal representation of your last chosen colour is #FF0000"
+    time.sleep(1)
+    assert dashr.find_element("#message-box").text == "The hexadecimal representation of your last chosen color is #FF0000"
     dashr.find_element("#color-selector").click()
     dashr.find_elements("div.VirtualizedSelectOption")[3].click()
-    assert dashr.find_element("#message-box").text == "The hexadecimal representation of your last chosen colour is #FF0000"
+    time.sleep(1)
+    assert dashr.find_element("#message-box").text == "The hexadecimal representation of your last chosen color is #FF0000"
     dashr.find_element("#color-selector").click()
     dashr.find_elements("div.VirtualizedSelectOption")[1].click()
-    assert dashr.find_element("#message-box").text == "The hexadecimal representation of your last chosen colour is #00FF00"
+    time.sleep(1)
+    assert dashr.find_element("#message-box").text == "The hexadecimal representation of your last chosen color is #00FF00"
     dashr.find_element("#color-selector").click()
     dashr.find_elements("div.VirtualizedSelectOption")[3].click()
-    assert dashr.find_element("#message-box").text == "The hexadecimal representation of your last chosen colour is #00FF00"
+    time.sleep(1)
+    assert dashr.find_element("#message-box").text == "The hexadecimal representation of your last chosen color is #00FF00"
     dashr.find_element("#color-selector").click()
     dashr.find_elements("div.VirtualizedSelectOption")[2].click()
-    assert dashr.find_element("#message-box").text == "The hexadecimal representation of your last chosen colour is #0000FF"
+    time.sleep(1)
+    assert dashr.find_element("#message-box").text == "The hexadecimal representation of your last chosen color is #0000FF"
     dashr.find_element("#color-selector").click()
     dashr.find_elements("div.VirtualizedSelectOption")[3].click()
-    assert dashr.find_element("#message-box").text == "The hexadecimal representation of your last chosen colour is #0000FF"
+    time.sleep(1)
+    assert dashr.find_element("#message-box").text == "The hexadecimal representation of your last chosen color is #0000FF"
+    dashr.find_element("#multi-selector").click()
+    time.sleep(1)
+    assert dashr.find_element("#message-box").text == "Multiple color values: #FF0000, #00FF00, #0000FF returned!"

--- a/tests/integration/callbacks/test_no_update.py
+++ b/tests/integration/callbacks/test_no_update.py
@@ -80,7 +80,6 @@ def test_rsnu001_no_update(dashr):
         "#message-box",
         "The hexadecimal representation of your last chosen color is #FF0000"
     )
-    assert dashr.find_element("#message-box").text == "The hexadecimal representation of your last chosen color is #FF0000"
     dashr.find_element("#color-selector").click()
     dashr.find_elements("div.VirtualizedSelectOption")[3].click()
     time.sleep(1)
@@ -91,7 +90,6 @@ def test_rsnu001_no_update(dashr):
         "#message-box",
         "The hexadecimal representation of your last chosen color is #00FF00"
     )
-    assert dashr.find_element("#message-box").text == "The hexadecimal representation of your last chosen color is #00FF00"
     dashr.find_element("#color-selector").click()
     dashr.find_elements("div.VirtualizedSelectOption")[3].click()
     time.sleep(1)
@@ -102,7 +100,6 @@ def test_rsnu001_no_update(dashr):
         "#message-box",
         "The hexadecimal representation of your last chosen color is #0000FF"
     )
-    assert dashr.find_element("#message-box").text == "The hexadecimal representation of your last chosen color is #0000FF"
     dashr.find_element("#color-selector").click()
     dashr.find_elements("div.VirtualizedSelectOption")[3].click()
     time.sleep(1)
@@ -112,4 +109,3 @@ def test_rsnu001_no_update(dashr):
         "#message-box2",
         "Multiple color values: #FF0000, #00FF00, #0000FF returned!"
     )
-    assert dashr.find_element("#message-box2").text == "Multiple color values: #FF0000, #00FF00, #0000FF returned!"

--- a/tests/integration/callbacks/test_no_update.py
+++ b/tests/integration/callbacks/test_no_update.py
@@ -100,4 +100,4 @@ def test_rsnu001_no_update(dashr):
     assert dashr.find_element("#message-box").text == "The hexadecimal representation of your last chosen color is #0000FF"
     dashr.find_element("#multi-selector").click()
     time.sleep(1)
-    assert dashr.find_element("#message-box").text == "Multiple color values: #FF0000, #00FF00, #0000FF returned!"
+    assert dashr.find_element("#message-box2").text == "Multiple color values: #FF0000, #00FF00, #0000FF returned!"

--- a/tests/integration/callbacks/test_no_update.py
+++ b/tests/integration/callbacks/test_no_update.py
@@ -1,0 +1,63 @@
+from selenium.webdriver.support.select import Select
+
+app = """
+library(dash)
+library(dashHtmlComponents)
+library(dashCoreComponents)
+
+app <- Dash$new()
+
+app$layout(
+  htmlDiv(list(
+    dccDropdown(options = list(
+      list(label = "Red", value = "#FF0000"),
+      list(label = "Green", value = "#00FF00"),      
+      list(label = "Blue", value = "#0000FF"),
+      list(label = "Do nothing", value = "nothing")
+    ),
+    id = "color-selector"),
+    htmlDiv(id='message-box',
+            children='Please select a colour choice from the dropdown menu.')
+  )
+  )
+)
+
+app$callback(output=list(id='message-box', property='children'),
+             params=list(
+               input(id='color-selector', property='value')),
+             function(color)
+             {
+               if (color %in% c("#FF0000", "#00FF00", "#0000FF")) {
+                 msg <- sprintf("The hexadecimal representation of your last chosen colour is %s",
+                                color)
+                 return(msg)
+               } else {
+                 return(dashNoUpdate())
+               }
+             }
+)
+
+app$run_server()
+"""
+
+
+def test_rsnu001_no_update(dashr):
+    dashr.start_server(app)
+    dashr.find_element("#color-selector").click()
+    dashr.find_elements("div.VirtualizedSelectOption")[0].click()
+    assert dashr.find_element("#message-box").text == "The hexadecimal representation of your last chosen colour is #FF0000"
+    dashr.find_element("#color-selector").click()
+    dashr.find_elements("div.VirtualizedSelectOption")[3].click()
+    assert dashr.find_element("#message-box").text == "The hexadecimal representation of your last chosen colour is #FF0000"
+    dashr.find_element("#color-selector").click()
+    dashr.find_elements("div.VirtualizedSelectOption")[1].click()
+    assert dashr.find_element("#message-box").text == "The hexadecimal representation of your last chosen colour is #00FF00"
+    dashr.find_element("#color-selector").click()
+    dashr.find_elements("div.VirtualizedSelectOption")[3].click()
+    assert dashr.find_element("#message-box").text == "The hexadecimal representation of your last chosen colour is #00FF00"
+    dashr.find_element("#color-selector").click()
+    dashr.find_elements("div.VirtualizedSelectOption")[2].click()
+    assert dashr.find_element("#message-box").text == "The hexadecimal representation of your last chosen colour is #0000FF"
+    dashr.find_element("#color-selector").click()
+    dashr.find_elements("div.VirtualizedSelectOption")[3].click()
+    assert dashr.find_element("#message-box").text == "The hexadecimal representation of your last chosen colour is #0000FF"

--- a/tests/integration/callbacks/test_no_update.py
+++ b/tests/integration/callbacks/test_no_update.py
@@ -76,7 +76,10 @@ def test_rsnu001_no_update(dashr):
     dashr.start_server(app)
     dashr.find_element("#color-selector").click()
     dashr.find_elements("div.VirtualizedSelectOption")[0].click()
-    time.sleep(1)
+    dashr.wait_for_text_to_equal(
+        "#message-box",
+        "The hexadecimal representation of your last chosen color is #FF0000"
+    )
     assert dashr.find_element("#message-box").text == "The hexadecimal representation of your last chosen color is #FF0000"
     dashr.find_element("#color-selector").click()
     dashr.find_elements("div.VirtualizedSelectOption")[3].click()
@@ -84,7 +87,10 @@ def test_rsnu001_no_update(dashr):
     assert dashr.find_element("#message-box").text == "The hexadecimal representation of your last chosen color is #FF0000"
     dashr.find_element("#color-selector").click()
     dashr.find_elements("div.VirtualizedSelectOption")[1].click()
-    time.sleep(1)
+    dashr.wait_for_text_to_equal(
+        "#message-box",
+        "The hexadecimal representation of your last chosen color is #00FF00"
+    )
     assert dashr.find_element("#message-box").text == "The hexadecimal representation of your last chosen color is #00FF00"
     dashr.find_element("#color-selector").click()
     dashr.find_elements("div.VirtualizedSelectOption")[3].click()
@@ -92,12 +98,18 @@ def test_rsnu001_no_update(dashr):
     assert dashr.find_element("#message-box").text == "The hexadecimal representation of your last chosen color is #00FF00"
     dashr.find_element("#color-selector").click()
     dashr.find_elements("div.VirtualizedSelectOption")[2].click()
-    time.sleep(1)
+    dashr.wait_for_text_to_equal(
+        "#message-box",
+        "The hexadecimal representation of your last chosen color is #0000FF"
+    )
     assert dashr.find_element("#message-box").text == "The hexadecimal representation of your last chosen color is #0000FF"
     dashr.find_element("#color-selector").click()
     dashr.find_elements("div.VirtualizedSelectOption")[3].click()
     time.sleep(1)
     assert dashr.find_element("#message-box").text == "The hexadecimal representation of your last chosen color is #0000FF"
     dashr.find_element("#multi-selector").click()
-    time.sleep(1)
+    dashr.wait_for_text_to_equal(
+        "#message-box2",
+        "Multiple color values: #FF0000, #00FF00, #0000FF returned!"
+    )
     assert dashr.find_element("#message-box2").text == "Multiple color values: #FF0000, #00FF00, #0000FF returned!"


### PR DESCRIPTION
This PR proposes to introduce a function entitled `dashNoUpdate()` which functions analogously to `dash.no_update` in Python, although the implementation differs slightly.

As with its counterpart, the function permits developers to selectively prevent one or more outputs from updating the layout. Currently, `dashNoUpdate()` only supports single-output callbacks, but should be easily extended to the multiple outputs scenario when that feature is available in R. 

Additionally, the `response$body` returned is an empty character string, with a `response$status` of `204`:

https://github.com/plotly/dashR/blob/b23c24855fa8a7655464c38b907fba4c72c7bfbc/R/dash.R#L294-L299

Closes #25.

@Marc-Andre-Rivet 