### PR TITLE
Better handling for user-defined error conditions in debug mode

### DIFF
--- a/R/dash.R
+++ b/R/dash.R
@@ -286,7 +286,7 @@ Dash <- R6::R6Class(
 
         output_value <- getStackTrace(do.call(callback, callback_args),
                                       debug = private$debug,
-                                      pruned_errors = private$pruned_errors)
+                                      prune_errors = private$prune_errors)
   
         # reset callback context
         private$callback_context_ <- NULL
@@ -525,7 +525,7 @@ Dash <- R6::R6Class(
                           port = Sys.getenv('DASH_PORT', 8050), 
                           block = TRUE, 
                           showcase = FALSE, 
-                          pruned_errors = TRUE, 
+                          dev_tools_prune_errors = TRUE, 
                           debug = FALSE, 
                           dev_tools_ui = NULL,
                           dev_tools_props_check = NULL,
@@ -545,7 +545,7 @@ Dash <- R6::R6Class(
         self$config$props_check <- FALSE
       }
 
-      private$pruned_errors <- pruned_errors
+      private$prune_errors <- dev_tools_prune_errors
       private$debug <- debug
       
       self$server$ignite(block = block, showcase = showcase, ...)
@@ -569,7 +569,7 @@ Dash <- R6::R6Class(
     
     # initialize flags for debug mode and stack pruning,
     debug = NULL,
-    pruned_errors = NULL,
+    prune_errors = NULL,
     stack_message = NULL,
 
     # callback context

--- a/R/utils.R
+++ b/R/utils.R
@@ -685,7 +685,7 @@ stackTraceToHTML <- function(call_stack,
 # and capture the call stack. By default, the call
 # stack will be "pruned" of error handling functions
 # for greater readability.
-getStackTrace <- function(expr, debug = FALSE, pruned_errors = TRUE) {
+getStackTrace <- function(expr, debug = FALSE, prune_errors = TRUE) {
   if(debug) {
     tryCatch(withCallingHandlers(
       expr,
@@ -711,7 +711,7 @@ getStackTrace <- function(expr, debug = FALSE, pruned_errors = TRUE) {
           
           reverseStack <- rev(calls)
           
-          if (pruned_errors) {
+          if (prune_errors) {
             # this line should match the last occurrence of the function
             # which raised the error within the call stack; prune here
             indexFromLast <- match(TRUE, lapply(reverseStack, function(currentCall) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -771,8 +771,6 @@ getStackTrace <- function(expr, debug = FALSE, prune_errors = TRUE) {
             
           })
           
-          reverseStack <- rev(calls)
-          
           if (prune_errors) {
             # this line should match the last occurrence of the function
             # which raised the error within the call stack; prune here

--- a/tests/integration/callbacks/test_handle_stop.py
+++ b/tests/integration/callbacks/test_handle_stop.py
@@ -1,0 +1,46 @@
+from selenium.webdriver.support.select import Select
+
+app = """
+library(dash)
+library(dashHtmlComponents)
+library(dashCoreComponents)
+
+app <- Dash$new()
+
+app$layout(
+  htmlDiv(
+    list(
+      dccDropdown(options = list(
+        list(label = "Red", value = "#FF0000"),
+        list(label = "Throw error", value = "error")
+      ),
+      id = "input-choice",
+      value = "error"),
+      htmlDiv(id="div-choice")
+    )
+  )
+)
+
+app$callback(output(id = 'div-choice', property = 'children'),
+             list(input(id = 'input-choice', property = 'value')),
+             function(choice) {
+               if (choice == "error") {
+                 stop(simpleError("Throwing an error by request"))
+                 }
+               if (!is.null(unlist(choice))) {
+                 return(sprintf("Choice was %s", choice))
+                 } else {
+                   return(sprintf("Make a choice"))
+                   }
+               })
+
+app$run_server(debug=TRUE)
+"""
+
+
+def test_rshs001_handle_stop(dashr):
+    dashr.start_server(app)
+    dashr.wait_for_text_to_equal(
+        ".dash-fe-error__title",
+        "Callback error updating div-choice.children"
+    )


### PR DESCRIPTION
As noted in #115, `getStackTrace` behaves a bit unexpectedly when a user defined error is encountered within a callback while in debug mode, e.g.

```
    if (city == "Winnipeg")
      stop(simpleError("Winnipeg?"))
```

ought to produce the following console text while sending a traceback up to the dev tools UI:

```
 ### DashR Traceback (most recent/innermost call last) ###
    1: getStackTrace
    2: do.call
    3: <anonymous> function(city, tempscale)
    4: stop
in debug mode, catching error as warning ...
warning: Execution error in stop: Winnipeg? from NULL
```

However, the traceback was not provided previously in such cases, and a JS error could be thrown in the browser instead, halting app execution. 

This PR proposes to address the problem by introducing conditional logic to identify calls of class `simpleError`, and to deparse the calls so that they may be treated as strings when constructing the `stack_message` object. 

The problem is that `stop` is a `symbol` in R, and attempting to naively treat it as a string may throw the following error:

```
Error in sprintf(template, header, throwing_call, error_message, formattedStack) : 
  invalid type of argument[2]: 'symbol'
```

which can prevent the traceback from being returned. The key additions are

https://github.com/plotly/dashR/blob/b170cfa72dc52a335a3d86763fad731fa27fcb6c/R/utils.R#L698-L707

https://github.com/plotly/dashR/blob/b170cfa72dc52a335a3d86763fad731fa27fcb6c/R/utils.R#L738-L747

https://github.com/plotly/dashR/blob/b170cfa72dc52a335a3d86763fad731fa27fcb6c/R/utils.R#L762-L770

Closes #115.