### PR TITLE
Require patched version of reqres to handle cookies containing multiple "="

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,8 @@ Collate:
   'internal.R'
 Remotes: plotly/dash-html-components@17da1f4,
   plotly/dash-core-components@cc1e654,
-  plotly/dash-table@042ad65
+  plotly/dash-table@042ad65,
+  plotly/reqres@55072ab
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true


### PR DESCRIPTION
As noted in thomasp85/reqres/pull/9, `parse_cookies` may throw an error if cookies containing multiple instances of `=` are encountered (such as those related to Google Analytics). 

This PR modifies the `DESCRIPTION` file to pull down a patched version of `requests.R` which splits the cookie strings in two, at the first `=` only.