### PR TITLE
Add line number context to stack traces when srcrefs are available

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,6 +37,7 @@ Remotes: plotly/dash-html-components@17da1f4,
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
+KeepSource: true
 RoxygenNote: 6.1.1
 Roxygen: list(markdown = TRUE)
 URL: https://github.com/plotly/dashR

--- a/R/dash.R
+++ b/R/dash.R
@@ -525,18 +525,18 @@ Dash <- R6::R6Class(
         private$updateReloadHash()
         private$index()
         
-        viewer <- getOption("viewer")
+        show_viewer <- !(is.null(getOption("viewer"))) && (dynGet("show_viewer") == TRUE)
         host <- dynGet("host")
         port <- dynGet("port")
         
         app_url <- paste0("http://", host, ":", port)
         
-        if (!is.null(viewer) && host %in% c("localhost", "127.0.0.1"))
+        if (show_viewer && host %in% c("localhost", "127.0.0.1")) 
           rstudioapi::viewer(app_url)
-        else {
+        else if (show_viewer) {
           warning("RStudio viewer not supported; ensure that host is 'localhost' or '127.0.0.1' and that you are using RStudio to run your app. Opening default browser...")
           utils::browseURL(app_url)
-        }
+          }
       })
 
       # user-facing fields
@@ -611,7 +611,7 @@ Dash <- R6::R6Class(
                           port = Sys.getenv('DASH_PORT', 8050), 
                           block = TRUE, 
                           showcase = FALSE, 
-                          viewer = FALSE,
+                          show_viewer = FALSE,
                           dev_tools_prune_errors = TRUE, 
                           debug = FALSE, 
                           dev_tools_ui = NULL,

--- a/R/dash.R
+++ b/R/dash.R
@@ -525,15 +525,15 @@ Dash <- R6::R6Class(
         private$updateReloadHash()
         private$index()
         
-        show_viewer <- !(is.null(getOption("viewer"))) && (dynGet("show_viewer") == TRUE)
+        use_viewer <- !(is.null(getOption("viewer"))) && (dynGet("use_viewer") == TRUE)
         host <- dynGet("host")
         port <- dynGet("port")
         
         app_url <- paste0("http://", host, ":", port)
         
-        if (show_viewer && host %in% c("localhost", "127.0.0.1")) 
+        if (use_viewer && host %in% c("localhost", "127.0.0.1")) 
           rstudioapi::viewer(app_url)
-        else if (show_viewer) {
+        else if (use_viewer) {
           warning("RStudio viewer not supported; ensure that host is 'localhost' or '127.0.0.1' and that you are using RStudio to run your app. Opening default browser...")
           utils::browseURL(app_url)
           }
@@ -611,7 +611,7 @@ Dash <- R6::R6Class(
                           port = Sys.getenv('DASH_PORT', 8050), 
                           block = TRUE, 
                           showcase = FALSE, 
-                          show_viewer = FALSE,
+                          use_viewer = FALSE,
                           dev_tools_prune_errors = TRUE, 
                           debug = FALSE, 
                           dev_tools_ui = NULL,

--- a/R/utils.R
+++ b/R/utils.R
@@ -696,7 +696,7 @@ printCallStack <- function(call_stack, header=TRUE) {
         ": ",
         call_stack,
         " ",
-        lapply(call_stack, attr, "lineref")
+        lapply(call_stack, attr, "flineref")
         )
     ),
     stderr()
@@ -775,7 +775,9 @@ getStackTrace <- function(expr, debug = FALSE, prune_errors = TRUE) {
               currentCall <- deparse(completeCall)[1]
             else
               currentCall <- completeCall[[1]]
-            attr(currentCall, "lineref") <- getLineWithError(completeCall, formatted=TRUE)
+            
+            attr(currentCall, "flineref") <- getLineWithError(completeCall, formatted=TRUE)
+            attr(currentCall, "lineref") <- getLineWithError(completeCall, formatted=FALSE)
 
             if (is.function(currentCall) & !is.primitive(currentCall)) {
               constructedCall <- paste0("<anonymous> function(",

--- a/R/utils.R
+++ b/R/utils.R
@@ -769,13 +769,13 @@ getStackTrace <- function(expr, debug = FALSE, prune_errors = TRUE) {
             # some calls in the stack are symbol (name) objects, while others
             # are calls, which must be deparsed; the first element in the vector
             # should be the function signature
-            if (is.name(completeCall[[1]])) 
+            if (is.name(completeCall[[1]]))
               currentCall <- as.character(completeCall[[1]])
-            else if (is.call(completeCall[[1]])) 
+            else if (is.call(completeCall[[1]]))
               currentCall <- deparse(completeCall)[1]
             else
               currentCall <- completeCall[[1]]
-            
+
             attr(currentCall, "flineref") <- getLineWithError(completeCall, formatted=TRUE)
             attr(currentCall, "lineref") <- getLineWithError(completeCall, formatted=FALSE)
 
@@ -789,7 +789,7 @@ getStackTrace <- function(expr, debug = FALSE, prune_errors = TRUE) {
             }
 
           })
-          
+
           if (prune_errors) {
             # this line should match the last occurrence of the function
             # which raised the error within the call stack; prune here
@@ -865,7 +865,7 @@ getLineWithError <- function(currentCall, formatted=TRUE) {
       sprintf('Line %s in %s', srcref[[1]], srcfile$filename)
     }
   } else {
-    ""    
+    ""
   }
 }
 
@@ -968,12 +968,12 @@ getAppPath <- function() {
   cmd_args <- commandArgs(trailingOnly = FALSE)
   file_argument <- "--file="
   matched_arg <- grep(file_argument, cmd_args)
-  
+
   # if app is instantiated via Rscript, cmd_args should contain path
   if (length(matched_arg) > 0) {
     # Rscript
     return(normalizePath(sub(file_argument, "", cmd_args[matched_arg])))
-  } 
+  }
   # if app is instantiated via source(), sys.frames should contain path
   else if (!is.null(sys.frames()[[1]]$ofile)) {
     return(normalizePath(sys.frames()[[1]]$ofile))
@@ -1009,23 +1009,23 @@ countEnclosingFrames <- function(object) {
 
 changedAssets <- function(before, after) {
   # identify files that used to exist in the asset map,
-  # but which have been removed 
+  # but which have been removed
   deletedElements <-  before[which(is.na(match(before, after)))]
-  
+
   # identify files which were added since the last refresh
   addedElements <-  after[which(is.na(match(after, before)))]
-  
+
   # identify any items that have been updated since the last
   # refresh based on modification time attributes set in map
-  # 
+  #
   # in R, attributes are discarded when subsetting, so it's
   # necessary to subset the attributes being compared instead.
   # here we only compare objects which overlap
   before_modtimes <-attributes(before)$modtime[before %in% after]
   after_modtimes <- attributes(after)$modtime[after %in% before]
-    
+
   changedElements <- after[which(after_modtimes > before_modtimes)]
-  
+
   if (length(deletedElements) == 0) {
     deletedElements <- NULL
   }
@@ -1043,13 +1043,13 @@ changedAssets <- function(before, after) {
   )
 }
 
-dashLogger <- function(event = NULL, 
-                       message = NULL, 
-                       request = NULL, 
-                       time = Sys.time(), 
+dashLogger <- function(event = NULL,
+                       message = NULL,
+                       request = NULL,
+                       time = Sys.time(),
                        ...) {
   orange <- crayon::make_style("orange")
-  
+
   # dashLogger is being called from within fiery, and the Fire() object generator
   # is called from a private method within the Dash() R6 class; this makes
   # accessing variables set within Dash's private fields somewhat complicated
@@ -1057,22 +1057,22 @@ dashLogger <- function(event = NULL,
   # the following line retrieves the value of the silence_route_logging parameter,
   # which is nearly 20 frames up the stack; if it's not found, we'll assume FALSE
   silence_routes_logging <- dynGet("self", ifnotfound = FALSE)$config$silence_routes_logging
-  
+
   if (!is.null(event)) {
     msg <- sprintf("%s: %s", event, message)
-    
-    msg <- switch(event, error = crayon::red(msg), warning = crayon::yellow(msg), 
+
+    msg <- switch(event, error = crayon::red(msg), warning = crayon::yellow(msg),
                   message = crayon::blue(msg), msg)
-    
+
     # assign the status group for color coding
     if (event == "request") {
-      status_group <- as.integer(cut(request$respond()$status, 
+      status_group <- as.integer(cut(request$respond()$status,
                                      breaks = c(100, 200, 300, 400, 500, 600), right = FALSE))
-      
-      msg <- switch(status_group, crayon::blue$bold(msg), crayon::green$bold(msg), 
+
+      msg <- switch(status_group, crayon::blue$bold(msg), crayon::green$bold(msg),
                     crayon::cyan$bold(msg), orange$bold(msg), crayon::red$bold(msg))
     }
-    
+
     # if log messages are suppressed, report only server stop/start messages, errors, and warnings
     # otherwise, print everything to console
     if (event %in% c("start", "stop", "error", "warning") || !(silence_routes_logging)) {
@@ -1081,7 +1081,7 @@ dashLogger <- function(event = NULL,
     }
   }
 }
-  
+
 clientsideFunction <- function(namespace, function_name) {
   return(list(namespace=namespace, function_name=function_name))
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -836,7 +836,7 @@ getStackTrace <- function(expr, debug = FALSE, prune_errors = TRUE) {
                                             conditionMessage(e))
 
           assign("stack_message", value=stack_message,
-                 envir=sys.frame(countEnclosingEnvs("private"))$private)
+                 envir=sys.frame(countEnclosingFrames("private"))$private)
 
           printCallStack(functionsAsList)
         }
@@ -997,7 +997,7 @@ setModtimeAsAttr <- function(path) {
   }
 }
 
-countEnclosingEnvs <- function(object) {
+countEnclosingFrames <- function(object) {
   for (i in 1:sys.nframe()) {
     objs <- ls(envir=sys.frame(i))
     if (object %in% objs)

--- a/R/utils.R
+++ b/R/utils.R
@@ -859,14 +859,12 @@ getLineWithError <- function(currentCall, formatted=TRUE) {
     # filename
     srcfile <- attr(srcref, "srcfile", exact = TRUE)
     # line number
-    if (formatted) {
-      crayon::yellow$italic(sprintf('Line %s in %s', srcref[[1]], srcfile$filename))
-    } else {
-      sprintf('Line %s in %s', srcref[[1]], srcfile$filename)
-    }
-  } else {
+    context <- sprintf("-- %s, Line %s", srcfile$filename, srcref[[1]])
+    if (formatted)
+      context <- crayon::yellow$italic(context)
+    return(context)
+  } else
     ""
-  }
 }
 
 # This helper function drops error


### PR DESCRIPTION
This PR proposes to inspect `srcref` attributes, when available, for additional context when `debug=TRUE` and errors are reported in the console or the dev tools UI in-browser. This information is populated in several settings:
- for internal, packaged functions, when `KeepSource` is `true` in the package `DESCRIPTION` file
- when applications are interactively loaded via `source()` and `keep.source = TRUE` (the default in most cases)
- when `Rscript` is used to invoke `source` at the CLI, and `keep.source = TRUE` is explicitly provided as an argument to `source` (since `keep.source` does not default to `TRUE` in most cases)

Some function calls will not have `srcref` attributes populated, and for these no line number is currently displayed. We will continue to investigate whether this functionality can be provided.

The initially proposed implementation looks like this:

![image](https://user-images.githubusercontent.com/9809798/66937747-0a07c300-f00e-11e9-88a4-5e138954c373.png)

... and within the dev tools UI, it looks like this:

![image](https://user-images.githubusercontent.com/9809798/66938004-679c0f80-f00e-11e9-86b0-24d598881caf.png)

Since there are enclosing environments between the error handler within `getStackTrace` and the `private` field to which `stack_message` is passed, it is necessary to resolve the number of frames to ascend up the stack. The proposed `countEnclosingFrames` function is an initial attempt at introducing this functionality.

This PR also resolves an issue with the option to display apps within RStudio's viewer pane, and renames that option from `viewer` to `use_viewer`.

Closes #132. @chriddyp 