### PR TITLE
Disable percy finalize in test fixtures and use pytest --headless

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,8 @@ jobs:
             git clone --depth 1 https://github.com/plotly/dash.git
             cd dash && pip install -e .[testing] --quiet && cd ..
             export PATH=$PATH:/home/circleci/.local/bin/
-            pytest tests/integration/
+            pytest tests/integration/ --headless --nopercyfinalize
+            percy finalize --all
 
       - run:
           name: 🔎 Unit tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
             git clone --depth 1 https://github.com/plotly/dash.git
             cd dash && pip install -e .[testing] --quiet && cd ..
             export PATH=$PATH:/home/circleci/.local/bin/
-            pytest tests/integration/ --headless --nopercyfinalize
+            pytest --headless --nopercyfinalize tests/integration/
             percy finalize --all
 
       - run:


### PR DESCRIPTION
This PR proposes to make the following changes to the CircleCI configuration:

L40 is changed from
```
pytest tests/integration/
```

to

```
pytest tests/integration/ --headless --nopercyfinalize
```

and L41 is added:

```
percy finalize --all
```

which follows the guidance given in the Percy Snapshots section [here](https://dash.plot.ly/testing).

@alexcjohnson 