### PR TITLE
Minor fix for get_asset_url and documentation for same

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   "test": &test-template
     working_directory: ~/dashr
     docker:
-      - image: plotly/dashr:ci
+      - image: byronz/dashr:ci
         environment:
           PERCY_PARALLEL_TOTAL: '-1'
           PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 'True'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   "test": &test-template
     working_directory: ~/dashr
     docker:
-      - image: byronz/dashr:ci
+      - image: plotly/dashr:ci
         environment:
           PERCY_PARALLEL_TOTAL: '-1'
           PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 'True'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Additional line number context inserted when available within stack traces [#133](https://github.com/plotly/dashR/pull/133)
 - Integration and unit tests are now performed when commits are made to open pull requests
 - Support returning asset URLs via `app$get_asset_url` when app is loaded via `source()` or `APP_ROOT_PATH` environment variable is defined [#160](https://github.com/plotly/dashR/pull/160)
+- `url_base_pathname` added; mimics functionality in Dash for Python, sets defaults for `routes_pathname_prefix` and `requests_pathname_prefix` when not otherwise provided [#161](https://github.com/plotly/dashR/pull/161)
 
 ### Changed
 - `dash-renderer` updated to v1.2.2 [#137](https://github.com/plotly/dashR/pull/137)
@@ -25,6 +26,7 @@ All notable changes to this project will be documented in this file.
 - Patch for `reqres` package to handle cookies containing multiple "=" [#122](https://github.com/plotly/dashR/pull/122)
 - Handling for user-defined errors in callbacks implemented [#116](https://github.com/plotly/dashR/pull/116)
 - Fixes for hot reloading interval handling and refreshing apps within viewer pane [#148](https://github.com/plotly/dashR/pull/148)
+- `get_asset_url` checks `getAppPath()` as well as `DASH_APP_ROOT_PATH` environment variable when invoked [#161](https://github.com/plotly/dashR/pull/161)
 
 ## [0.1.0] - 2019-07-10
 ### Added

--- a/R/utils.R
+++ b/R/utils.R
@@ -457,7 +457,7 @@ valid_seq <- function(params) {
   }
 }
 
-resolve_prefix <- function(prefix, environment_var) {
+resolve_prefix <- function(prefix, environment_var, base_pathname) {
   if (!(is.null(prefix))) {
     assertthat::assert_that(is.character(prefix))
 
@@ -467,7 +467,11 @@ resolve_prefix <- function(prefix, environment_var) {
     if (prefix_env != "") {
       return(prefix_env)
     } else {
-      return("/")
+      env_base_pathname <- Sys.getenv("DASH_URL_BASE_PATHNAME")
+      if (env_base_pathname != "")
+        return(env_base_pathname)
+      else
+        return(base_pathname)
     }
   }
 }

--- a/man/Dash.Rd
+++ b/man/Dash.Rd
@@ -21,8 +21,9 @@ eager_loading = FALSE,
 assets_ignore = '',
 serve_locally = TRUE,
 meta_tags = NULL,
-routes_pathname_prefix = '/',
-requests_pathname_prefix = '/',
+url_base_pathname = '/',
+routes_pathname_prefix = NULL,
+requests_pathname_prefix = NULL,
 external_scripts = NULL,
 external_stylesheets = NULL,
 suppress_callback_exceptions = FALSE
@@ -45,19 +46,23 @@ and other files such as images will be served if requested. Default is \code{ass
 \code{assets_ignore} \tab \tab Character. A regular expression, to match assets to omit from
 immediate loading. Ignored files will still be served if specifically requested. You
 cannot use this to prevent access to sensitive files. \cr
-\code{serve_locally} \tab \tab Whether to serve HTML dependencies locally or
+\code{serve_locally} \tab \tab Logical. Whether to serve HTML dependencies locally or
 remotely (via URL).\cr
 \code{meta_tags} \tab \tab List of lists. HTML \code{<meta>}tags to be added to the index page.
 Each list element should have the attributes and values for one tag, eg:
 \code{list(name = 'description', content = 'My App')}.\cr
-\code{routes_pathname_prefix} \tab \tab a prefix applied to the backend routes.\cr
-\code{requests_pathname_prefix} \tab \tab a prefix applied to request endpoints
-made by Dash's front-end.\cr
-\code{external_scripts} \tab \tab An optional list of valid URLs from which
+\code{url_base_pathname} \tab \tab Character. A local URL prefix to use app-wide. Default is
+\code{/}. Both \code{requests_pathname_prefix} and \code{routes_pathname_prefix} default to \code{url_base_pathname}.
+Environment variable is \code{DASH_URL_BASE_PATHNAME}.\cr
+\code{routes_pathname_prefix} \tab \tab Character. A prefix applied to the backend routes.
+Environment variable is \code{DASH_ROUTES_PATHNAME_PREFIX}.\cr
+\code{requests_pathname_prefix} \tab \tab Character. A prefix applied to request endpoints
+made by Dash's front-end. Environment variable is \code{DASH_REQUESTS_PATHNAME_PREFIX}.\cr
+\code{external_scripts} \tab \tab List. An optional list of valid URLs from which
 to serve JavaScript source for rendered pages.\cr
-\code{external_stylesheets} \tab \tab An optional list of valid URLs from which
+\code{external_stylesheets} \tab \tab List. An optional list of valid URLs from which
 to serve CSS for rendered pages.\cr
-\code{suppress_callback_exceptions} \tab \tab Whether to relay warnings about
+\code{suppress_callback_exceptions} \tab \tab Logical. Whether to relay warnings about
 possible layout mis-specifications when registering a callback.
 }
 }
@@ -114,6 +119,14 @@ The \code{callback_context} method permits retrieving the inputs which triggered
 the firing of a given callback, and allows introspection of the input/state
 values given their names. It is only available from within a callback;
 attempting to use this method outside of a callback will result in a warning.
+}
+\item{\code{get_asset_url(asset_path, prefix)}}{
+The \code{get_asset_url} method permits retrieval of an asset's URL given its filename.
+For example, \code{app$get_asset_url('style.css')} should return \code{/assets/style.css} when
+\code{assets_folder = 'assets'}. By default, the prefix is the value of \code{requests_pathname_prefix},
+but this is configurable via the \code{prefix} parameter. Note: this method will
+present a warning and return \code{NULL} if the Dash app was not loaded via \code{source()}
+if the \code{DASH_APP_PATH} environment variable is undefined.
 }
 \item{\code{run_server(host =  Sys.getenv('DASH_HOST', "127.0.0.1"), port = Sys.getenv('DASH_PORT', 8050), block = TRUE, showcase = FALSE, ...)}}{
 The \code{run_server} method has 13 formal arguments, several of which are optional:


### PR DESCRIPTION
This PR proposes to introduce a check that `getAppPath()` returns `FALSE` if the environment variable `DASH_APP_ROOT_PATH` is undefined when a Dash app was launched without using `source()`. In addition, documentation is added for the method.

Additionally, this PR contributes the `url_base_pathname` parameter, which existed in Dash for Python but not in Dash for R.

@HammadTheOne 