### PR TITLE
Autoset routes and requests pathname prefixes if DASH_APP_NAME is set

### DIFF
--- a/R/dash.R
+++ b/R/dash.R
@@ -213,8 +213,8 @@ Dash <- R6::R6Class(
       private$in_viewer <- FALSE
 
       # config options
-      self$config$routes_pathname_prefix <- resolve_prefix(routes_pathname_prefix, "DASH_ROUTES_PATHNAME_PREFIX", url_base_pathname)
-      self$config$requests_pathname_prefix <- resolve_prefix(requests_pathname_prefix, "DASH_REQUESTS_PATHNAME_PREFIX", url_base_pathname)
+      self$config$routes_pathname_prefix <- resolvePrefix(routes_pathname_prefix, "DASH_ROUTES_PATHNAME_PREFIX", url_base_pathname)
+      self$config$requests_pathname_prefix <- resolvePrefix(requests_pathname_prefix, "DASH_REQUESTS_PATHNAME_PREFIX", url_base_pathname)
       self$config$external_scripts <- external_scripts
       self$config$external_stylesheets <- external_stylesheets
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -468,7 +468,7 @@ resolvePrefix <- function(prefix, environment_var, base_pathname) {
     env_base_pathname <- Sys.getenv("DASH_URL_BASE_PATHNAME")
     app_name <- Sys.getenv("DASH_APP_NAME")
     
-    else if (prefix_env != "")
+    if (prefix_env != "")
       return(prefix_env)
     else if (app_name != "")
       return(sprintf("/%s/", app_name))

--- a/R/utils.R
+++ b/R/utils.R
@@ -457,7 +457,7 @@ valid_seq <- function(params) {
   }
 }
 
-resolve_prefix <- function(prefix, environment_var, base_pathname) {
+resolvePrefix <- function(prefix, environment_var, base_pathname) {
   if (!(is.null(prefix))) {
     assertthat::assert_that(is.character(prefix))
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -463,16 +463,19 @@ resolve_prefix <- function(prefix, environment_var, base_pathname) {
 
     return(prefix)
   } else {
+    # Check environment variables
     prefix_env <- Sys.getenv(environment_var)
-    if (prefix_env != "") {
+    env_base_pathname <- Sys.getenv("DASH_URL_BASE_PATHNAME")
+    app_name <- Sys.getenv("DASH_APP_NAME")
+    
+    else if (prefix_env != "")
       return(prefix_env)
-    } else {
-      env_base_pathname <- Sys.getenv("DASH_URL_BASE_PATHNAME")
-      if (env_base_pathname != "")
-        return(env_base_pathname)
-      else
-        return(base_pathname)
-    }
+    else if (app_name != "")
+      return(sprintf("/%s/", app_name))
+    else if (env_base_pathname != "")
+      return(env_base_pathname)
+    else
+      return(base_pathname)
   }
 }
 


### PR DESCRIPTION
This PR proposes to modify the resolution logic for `resolve_prefix`, which is called by Dash when setting `self$routes_pathname_prefix` and `self$requests_pathname_prefix`:
- check if `routes_pathname_prefix` or `requests_pathname_prefix` has been passed to Dash for R directly, and use if available
- check if `DASH_ROUTES_PATHNAME_PREFIX` or `DASH_REQUESTS_PATHNAME_PREFIX` have been set in current environment, and use if available
- check if `DASH_APP_NAME` has been set in environment, and use if available
- check if `DASH_URL_BASE_PATHNAME` has been set in environment, and use if available
- return the value of `base_pathname` if resolution fails as directed above

In addition, the function name is camelCased instead of using snake case.