### PR TITLE
Send status code of 1 when unit tests fail

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
       - run:
           name: 🔎 Unit tests
           command: |
-              sudo Rscript -e 'testthat::test_dir("tests/")'
+              sudo Rscript -e 'res=devtools::test("tests/", reporter=default_reporter());df=as.data.frame(res);if(sum(df$failed) > 0 || any(df$error)) {q(status=1)}'
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
             . venv/bin/activate
             pip install -e git+https://github.com/plotly/dash.git#egg=dash[testing]
             export PATH=$PATH:/home/circleci/.local/bin/
-            pytest --log-cli-level DEBUG --nopercyfinalize --junitxml=test-reports/dashr.xml tests/integration/
+            pytest --nopercyfinalize --junitxml=test-reports/dashr.xml tests/integration/
       - store_artifacts:
           path: test-reports
       - store_test_results:

--- a/tests/testthat/test-index.R
+++ b/tests/testthat/test-index.R
@@ -46,7 +46,7 @@ test_that("Customizing title using `name` produces a warning", {
 
   expect_warning(
     Dash$new(name="Testing"),
-    "The supplied application title, 'Testings', should be set using the title() method, or passed via index_string() or interpolate_index(); it has been ignored, and 'dash' will be used instead.",
+    "The supplied application title, 'Testing', should be set using the title() method, or passed via index_string() or interpolate_index(); it has been ignored, and 'dash' will be used instead.",
     fixed=TRUE
   )
 })

--- a/tests/testthat/test-index.R
+++ b/tests/testthat/test-index.R
@@ -46,7 +46,7 @@ test_that("Customizing title using `name` produces a warning", {
 
   expect_warning(
     Dash$new(name="Testing"),
-    "The supplied application title, 'Testing', should be set using the title() method, or passed via index_string() or interpolate_index(); it has been ignored, and 'dash' will be used instead.",
+    "The supplied application title, 'Testings', should be set using the title() method, or passed via index_string() or interpolate_index(); it has been ignored, and 'dash' will be used instead.",
     fixed=TRUE
   )
 })


### PR DESCRIPTION
Currently, the unit test failures aren't properly detected in CI, as noted in https://github.com/plotly/dashR/issues/152. This is a limitation of the `testthat` package, which does not send a failure code even when tests have failed. 

The proposed edit to the CircleCI config should properly trigger a failure code; this PR will trigger an error initially to test whether the change works as intended.

Closes #152.

@Marc-Andre-Rivet 