### PR TITLE
Fix bug which prevented multiple outputs in callbacks returning Dash components in R

### DIFF
--- a/R/dash.R
+++ b/R/dash.R
@@ -399,7 +399,6 @@ Dash <- R6::R6Class(
       dash_update <- paste0(self$config$routes_pathname_prefix, "_dash-update-component")
       route$add_handler("post", dash_update, function(request, response, keys, ...) {
         request <- request_parse_json(request)
-
         if (!"output" %in% names(request$body)) {
           response$body <- "Couldn't find output component in request body"
           response$status <- 500L
@@ -474,7 +473,7 @@ Dash <- R6::R6Class(
 
           if (substr(request$body$output, 1, 2) == '..') {
             # omit return objects of class "no_update" from output_value
-            updatable_outputs <- "no_update" != vapply(output_value, class, character(1))
+            updatable_outputs <- vapply(output_value, function(x) !("no_update" %in% class(x)), logical(1))
             output_value <- output_value[updatable_outputs]
 
             # if multi-output callback, isolate the output IDs and properties

--- a/tests/integration/callbacks/test_multiple_outputs_return_callback.py
+++ b/tests/integration/callbacks/test_multiple_outputs_return_callback.py
@@ -1,0 +1,65 @@
+from selenium.webdriver.support.select import Select
+
+app_returning_component = """
+library(dash)
+library(dashHtmlComponents)
+library(dashCoreComponents)
+library(plotly)
+library(dashTable)
+
+app <- Dash$new()       
+app$layout(
+  htmlDiv(list(
+    htmlH1('Multi-outputs with callback returning component'),
+    htmlDiv(children = 'Click button to render or remove component here', id = 'inner-container'),
+    htmlButton('Render/Unrender', id='submit-val', n_clicks=0),
+    htmlDiv(children = 'Button clicked 0 times.', id = 'clicks-count')
+    ),
+    id = 'container'
+  )
+)
+
+app$callback(output=list(
+  output(id='clicks-count', property='children'),
+  output(id='inner-container', property='children')
+),
+params=list(
+  input(id='submit-val', property='n_clicks')
+),
+function(value) {
+  click_total <- as.numeric(value)
+  result <- htmlDiv('String in container', id = 'string-container')
+
+  if (click_total == 0) {
+    return(dashNoUpdate())
+  } else if (click_total %% 2 == 1) {
+    result <- 'String, no container'
+  }
+ 
+  return(list(sprintf('Button clicked %s times.', click_total),
+              result))
+}
+)
+app$run_server(debug=TRUE)
+"""
+
+
+def test_rsnu002_multiple_outputs(dashr):
+    dashr.start_server(app_returning_component)
+    dashr.wait_for_text_to_equal(
+        "#inner-container",
+        "Click button to render or remove component here"
+    )   
+    dashr.find_element("#submit-val").click()
+    dashr.wait_for_text_to_equal(
+         "#clicks-count",
+         "Button clicked 1 times."
+    )
+    assert dashr.find_element("#inner-container").text == "String, no container"
+    dashr.find_element("#submit-val").click()
+    dashr.wait_for_text_to_equal(
+         "#clicks-count",
+         "Button clicked 2 times."
+    )     
+    assert dashr.find_element("#string-container").text == "String in container"
+

--- a/tests/integration/callbacks/test_multiple_outputs_return_callback.py
+++ b/tests/integration/callbacks/test_multiple_outputs_return_callback.py
@@ -1,11 +1,7 @@
-from selenium.webdriver.support.select import Select
-
 app_returning_component = """
 library(dash)
 library(dashHtmlComponents)
 library(dashCoreComponents)
-library(plotly)
-library(dashTable)
 
 app <- Dash$new()       
 app$layout(


### PR DESCRIPTION
This PR proposes a minor modification to the way Dash for R's `_dash-update-component` handler resolves multiple outputs in callbacks which return one or more Dash components. This bug was discovered accidentally while fixing another bug in the Dash for R docs.

Previously, `updatable_outputs` implicitly assumed `output_value`'s elements were members of only one class, since the specified return type of `vapply` was `character(1)`:

https://github.com/plotly/dashR/blob/b3be88ddf5cc3b3b0cc5edd063068779638680ab/R/dash.R#L477-L478

This was insufficiently robust, since valid return values from Dash callbacks can be objects in R which are members of more than one class.

As an example, if a callback returns `list(htmlDiv(), "")`, the class membership of its elements would be 

```
> lapply(list(htmlDiv(), ""), class)
[[1]]
[1] "dash_component" "list"          

[[2]]
[1] "character"
```

The original definition of `updatable_outputs` would essentially attempt `vapply(list(htmlDiv(), ""), class, character(1))` which produces the cryptic error

```
Error in vapply(list(htmlDiv(), ""), class, character(1)) : 
  values must be length 1,
 but FUN(X[[1]]) result is length 2
```

By rewriting the original line as

```
updatable_outputs <- vapply(output_value, function(x) !("no_update" %in% class(x)), logical(1))
```

class membership is inspected more flexibly, and a logical result is returned in the `vapply` step instead of a `character` vector of class names.