### PR TITLE
Remove no IDs warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to `dash` will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.6.4] - 2020-07-14
+**Changed**
+- Removes warning message when an app is launched without any component ID's present in the layout (for more details, see [#457](https://github.com/plotly/dash-enterprise-docs/issues/457). 
+
+
 ## [0.6.3] - 2020-06-25
 **Changed**
 - `dash-renderer` updated to v1.5.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.6.4] - 2020-07-14
 **Changed**
-- Removes warning message when an app is launched without any component ID's present in the layout (for more details, see [#457](https://github.com/plotly/dash-enterprise-docs/issues/457). 
+- Removes warning message when an app is launched without any component ID's present in the layout. When writing callbacks it iss natural to assume that an ID is necessary, and this warning may be misleading for apps without callbacks (for more details, see [#216](https://github.com/plotly/dashR/pull/216). 
 
 
 ## [0.6.3] - 2020-06-25

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dash
 Title: An Interface to the Dash Ecosystem for Authoring Reactive Web Applications
-Version: 0.6.3
+Version: 0.6.4
 Authors@R: c(person("Chris", "Parmer", role = c("aut"), email = "chris@plotly.com"), person("Ryan Patrick", "Kyle", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-5829-9867"), email = "ryan@plotly.com"), person("Carson", "Sievert", role = c("aut"), comment = c(ORCID = "0000-0002-4958-2844")), person("Hammad", "Khan", role = c("aut"), email = "hammadkhan@plotly.com"), person(family = "Plotly Technologies", role = "cph")) 
 Description: A framework for building analytical web applications, Dash offers a pleasant and productive development experience. No JavaScript required.
 Depends:

--- a/R/dash.R
+++ b/R/dash.R
@@ -1226,13 +1226,7 @@ Dash <- R6::R6Class(
 
       # verify that layout ids are unique
       idx <- grep("props\\.id$", layout_nms)
-      if (!length(idx)) {
-        warning(
-          "No ids were found in the layout. ",
-          "Component ids are critical for targeting callbacks in your application",
-          call. = FALSE
-        )
-      }
+
       layout_ids <- as.character(layout_flat[idx])
       duped <- anyDuplicated(layout_ids) > 0
 


### PR DESCRIPTION
Based on the discussion in plotly/dash-enterprise-docs#457, it would make more sense for new and experienced users to avoid this warning message altogether, especially in the cases where we have apps that don't require layouts or have the layout written first. This PR removes that warning, and updates the Dash R version and changelog.

Closes plotly/dash-enterprise-docs#457.