### PR TITLE
Add support for user-defined server routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to `dash` will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Added
+- Dash for R now supports for user-defined routes and redirects via the `app$server_route` and `app$redirect` methods. [#225](https://github.com/plotly/dashR/pull/225)
+
 ## [0.7.1] - 2020-07-30
 ### Fixed
 - Fixes a minor bug in debug mode that prevented display of user-defined error messages when induced by invoking the `stop` function. [#220](https://github.com/plotly/dashR/pull/220).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
-- Dash for R now supports for user-defined routes and redirects via the `app$server_route` and `app$redirect` methods. [#225](https://github.com/plotly/dashR/pull/225)
+- Dash for R now supports user-defined routes and redirects via the `app$server_route` and `app$redirect` methods. [#225](https://github.com/plotly/dashR/pull/225)
 
 ## [0.7.1] - 2020-07-30
 ### Fixed

--- a/R/dash.R
+++ b/R/dash.R
@@ -594,10 +594,17 @@ Dash <- R6::R6Class(
     #'   TRUE
     #' })
     #'
-    #' # Example of a parameterized redirect with a wildcard for subpaths
+    #' # Example of a redirect with a wildcard for subpaths
     #' app$server_route('/getting-started/*', function(request, response, keys, ...) {
     #'   response$status <- 307L
     #'   response$set_header('Location', '/layout')
+    #'   TRUE
+    #' })
+    #'
+    #' # Example of a parameterized redirect with wildcard for subpaths
+    #' app$server_route('/accounts/:user_id/*', function(request, response, keys, ...) {
+    #'   response$status <- 307L
+    #'   response$set_header('Location', paste0('/users/', keys$user_id))
     #'   TRUE
     #' })
     server_route = function(path = NULL, handler = NULL, methods = "get") {
@@ -638,7 +645,7 @@ Dash <- R6::R6Class(
     #' # example of a simple single path-to-path redirect
     #' app$redirect("/getting-started", "/layout")
     #'
-    #' # example of a parameterized redirect using wildcards
+    #' # example of a redirect using wildcards
     #' app$redirect("/getting-started/*", "/layout/*")
     redirect = function(old_path = NULL, new_path = NULL, methods = "get") {
       if (is.null(old_path) || is.null(new_path)) {

--- a/R/dash.R
+++ b/R/dash.R
@@ -633,8 +633,9 @@ Dash <- R6::R6Class(
     #' path element, rather than restricting (as by default) to a single
     #' path element. For example, it is possible to catch requests to multiple
     #' subpaths using a wildcard. For more information, see \link{Route}.
-    #' @param new_path Character. Same as `old_path`, but represents the
-    #' new path which the client should load instead.
+    #' @param new_path Character or function. Same as `old_path`, but represents the
+    #' new path which the client should load instead. If a function is
+    #' provided instead of a string, it should have `keys` within its formals.
     #' @param methods Character. A string indicating the request method
     #' (in lower case, e.g. 'get', 'put', etc.), as used by `reqres`. The
     #' default is `get`. For more information, see \link{Route}.

--- a/R/dash.R
+++ b/R/dash.R
@@ -109,7 +109,7 @@ Dash <- R6::R6Class(
       # ------------------------------------------------------------
       router <- routr::RouteStack$new()
       server$set_data("user-routes", list()) # placeholder for custom routes
-      
+ 
       # ensure that assets_folder is neither NULL nor character(0)
       if (!(is.null(private$assets_folder)) & length(private$assets_folder) != 0) {
         if (!(dir.exists(private$assets_folder)) && gsub("/+", "", assets_folder) != "assets") {
@@ -578,40 +578,7 @@ Dash <- R6::R6Class(
                                  "handler" = handler)
 
       self$server$set_data("user-routes", user_routes)
-    },
-
-    show_routes = function() {
-      if (length(self$server$get_data("user-routes")) > 0) {
-        return(self$server$get_data("user-routes"))
-      }
-      message("No user-defined routes currently exist.")
-    },
-    
-    remove_routes = function(routes=NULL) {
-      if (length(self$server$get_data("user-routes")) > 0) {
-        if (is.null(routes)) {
-          stop("The name of a user-defined route to remove was not provided; please ensure that 'routes' is not NULL.", call.=FALSE)
-        } else {
-          user_routes <- self$server$get_data("user-routes")
-          
-          if (!(all(routes %in% names(user_routes)))) {
-            stop(paste0("The following user-defined routes were not found: ", 
-                        paste(setdiff(routes, user_routes),
-                              collapse = ", ")
-                        )
-            )
-          }
-          for (route in routes) {
-            user_routes[[route]] <- NULL
-          }
-          self$server$set_data("user-routes", user_routes)
-          message(paste0("The following user-defined routes were removed: ",
-                         paste(routes, collapse = ", ")))
-        }
-      } else 
-          message("No user-defined routes currently exist.")
-    },
-    
+    },    
 
     # ------------------------------------------------------------------------
     # dash layout methods

--- a/R/dash.R
+++ b/R/dash.R
@@ -658,27 +658,21 @@ Dash <- R6::R6Class(
         stop("The redirect method requires that both an old path and a new path are specified. Please ensure these arguments are non-missing.", call.=FALSE)
       }
 
-      user_routes <- self$server$get_data("user-routes")
-
       if (is.function(new_path)) {
         handler <- function(request, response, keys, ...) {
           response$status <- 301L
           response$set_header('Location', new_path(keys))
           TRUE
         }
-      }
-      else {
+      } else {
         handler <- function(request, response, keys, ...) {
           response$status <- 301L
           response$set_header('Location', new_path)
           TRUE
         }
       }
-      user_routes[[old_path]] <- list("path" = old_path,
-                                      "handler" = handler,
-                                      "methods" = methods)
-
-      self$server$set_data("user-routes", user_routes)
+    
+      self$server_route(old_path, handler)
     },
 
     # ------------------------------------------------------------------------

--- a/man/Dash.Rd
+++ b/man/Dash.Rd
@@ -29,10 +29,17 @@ app$server_route('/getting-started', function(request, response, keys, ...) {
   TRUE
 })
 
-# Example of a parameterized redirect with a wildcard for subpaths
+# Example of a redirect with a wildcard for subpaths
 app$server_route('/getting-started/*', function(request, response, keys, ...) {
   response$status <- 307L
   response$set_header('Location', '/layout')
+  TRUE
+})
+
+# Example of a parameterized redirect with wildcard for subpaths
+app$server_route('/accounts/:user_id/*', function(request, response, keys, ...) {
+  response$status <- 307L
+  response$set_header('Location', paste0('/users/', keys$user_id))
   TRUE
 })
 
@@ -46,8 +53,13 @@ app <- Dash$new()
 # example of a simple single path-to-path redirect
 app$redirect("/getting-started", "/layout")
 
-# example of a parameterized redirect using wildcards
+# example of a redirect using wildcards
 app$redirect("/getting-started/*", "/layout/*")
+
+# example of a parameterized redirect using a function for new_path,
+# which requires passing in keys to take advantage of subpaths within
+# old_path that are preceded by a colon (e.g. :user_id):
+app$redirect("/accounts/:user_id/*", function(keys) paste0("/users/", keys$user_id))
 
 ## ------------------------------------------------
 ## Method `Dash$interpolate_index`
@@ -297,10 +309,17 @@ app$server_route('/getting-started', function(request, response, keys, ...) {
   TRUE
 })
 
-# Example of a parameterized redirect with a wildcard for subpaths
+# Example of a redirect with a wildcard for subpaths
 app$server_route('/getting-started/*', function(request, response, keys, ...) {
   response$status <- 307L
   response$set_header('Location', '/layout')
+  TRUE
+})
+
+# Example of a parameterized redirect with wildcard for subpaths
+app$server_route('/accounts/:user_id/*', function(request, response, keys, ...) {
+  response$status <- 307L
+  response$set_header('Location', paste0('/users/', keys$user_id))
   TRUE
 })
 }
@@ -351,8 +370,13 @@ app <- Dash$new()
 # example of a simple single path-to-path redirect
 app$redirect("/getting-started", "/layout")
 
-# example of a parameterized redirect using wildcards
+# example of a redirect using wildcards
 app$redirect("/getting-started/*", "/layout/*")
+
+# example of a parameterized redirect using a function for new_path,
+# which requires passing in keys to take advantage of subpaths within
+# old_path that are preceded by a colon (e.g. :user_id):
+app$redirect("/accounts/:user_id/*", function(keys) paste0("/users/", keys$user_id))
 }
 \if{html}{\out{</div>}}
 

--- a/man/Dash.Rd
+++ b/man/Dash.Rd
@@ -13,6 +13,20 @@ A framework for building analytical web applications, Dash offers a pleasant and
 \examples{
 
 ## ------------------------------------------------
+## Method `Dash$server_route`
+## ------------------------------------------------
+
+library(dash)
+app <- Dash$new()
+
+# A handler to serve 418 errors; see https://tools.ietf.org/html/rfc7168
+app$server_route("/teapot", function(request, response, keys, ...) {
+  response$status <- 418L
+  response$body('may be short and stout')
+  TRUE
+})
+
+## ------------------------------------------------
 ## Method `Dash$interpolate_index`
 ## ------------------------------------------------
 
@@ -97,6 +111,7 @@ where the application is making API calls.}
 \subsection{Public methods}{
 \itemize{
 \item \href{#method-new}{\code{Dash$new()}}
+\item \href{#method-server_route}{\code{Dash$server_route()}}
 \item \href{#method-layout_get}{\code{Dash$layout_get()}}
 \item \href{#method-layout}{\code{Dash$layout()}}
 \item \href{#method-react_version_set}{\code{Dash$react_version_set()}}
@@ -197,6 +212,57 @@ clientside callback.}
 }
 \if{html}{\out{</div>}}
 }
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-server_route"></a>}}
+\if{latex}{\out{\hypertarget{method-server_route}{}}}
+\subsection{Method \code{server_route()}}{
+Connect a URL to a custom server route
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Dash$server_route(path = NULL, handler = NULL, methods = "get")}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{path}}{Character. Represents a URL path comprised of strings, parameters
+(strings prefixed with :), and wildcards (*), separated by /. Wildcards can
+be used to match any path element, rather than restricting (as by default) to
+a single path element. For example, it is possible to catch requests to multiple
+subpaths using a wildcard. For more information, see \link{Route}.}
+
+\item{\code{handler}}{Adds a handler function to the specified method and path.
+For more information, see \link{Route}.}
+
+\item{\code{methods}}{Character. A string indicating the request method (in lower case,
+e.g. 'get', 'put', etc.), as used by \code{reqres}. For more information, see \link{Route}.}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Details}{
+\code{fiery}, the underlying web service framework upon which Dash for R is based,
+supports custom routing through plugins. While convenient, the plugin API
+providing this functionality is different from that provided by Flask, as
+used by Dash for Python. This method wraps the pluggable routing of \code{routr}
+routes in a manner that should feel slightly more idiomatic to Dash users.
+}
+
+\subsection{Examples}{
+\if{html}{\out{<div class="r example copy">}}
+\preformatted{library(dash)
+app <- Dash$new()
+
+# A handler to serve 418 errors; see https://tools.ietf.org/html/rfc7168
+app$server_route("/teapot", function(request, response, keys, ...) {
+  response$status <- 418L
+  response$body('may be short and stout')
+  TRUE
+})
+}
+\if{html}{\out{</div>}}
+
+}
+
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-layout_get"></a>}}

--- a/man/Dash.Rd
+++ b/man/Dash.Rd
@@ -347,8 +347,9 @@ path element, rather than restricting (as by default) to a single
 path element. For example, it is possible to catch requests to multiple
 subpaths using a wildcard. For more information, see \link{Route}.}
 
-\item{\code{new_path}}{Character. Same as \code{old_path}, but represents the
-new path which the client should load instead.}
+\item{\code{new_path}}{Character or function. Same as \code{old_path}, but represents the
+new path which the client should load instead. If a function is
+provided instead of a string, it should have \code{keys} within its formals.}
 
 \item{\code{methods}}{Character. A string indicating the request method
 (in lower case, e.g. 'get', 'put', etc.), as used by \code{reqres}. The

--- a/man/Dash.Rd
+++ b/man/Dash.Rd
@@ -19,12 +19,35 @@ A framework for building analytical web applications, Dash offers a pleasant and
 library(dash)
 app <- Dash$new()
 
-# A handler to serve 418 errors; see https://tools.ietf.org/html/rfc7168
-app$server_route("/teapot", function(request, response, keys, ...) {
-  response$status <- 418L
-  response$body('may be short and stout')
+# A handler to redirect requests with `307` status code (temporary redirects); 
+# for permanent redirects (`301`), see the `redirect` method described below
+# 
+# A simple single path-to-path redirect
+app$server_route('/getting-started', function(request, response, keys, ...) {
+  response$status <- 307L
+  response$set_header('Location', '/layout')
   TRUE
 })
+
+# Example of a parameterized redirect with a wildcard for subpaths
+app$server_route('/getting-started/*', function(request, response, keys, ...) {
+  response$status <- 307L
+  response$set_header('Location', '/layout')
+  TRUE
+})
+
+## ------------------------------------------------
+## Method `Dash$redirect`
+## ------------------------------------------------
+
+library(dash)
+app <- Dash$new()
+
+# example of a simple single path-to-path redirect
+app$redirect("/getting-started", "/layout")
+
+# example of a parameterized redirect using wildcards
+app$redirect("/getting-started/*", "/layout/*")
 
 ## ------------------------------------------------
 ## Method `Dash$interpolate_index`
@@ -112,6 +135,7 @@ where the application is making API calls.}
 \itemize{
 \item \href{#method-new}{\code{Dash$new()}}
 \item \href{#method-server_route}{\code{Dash$server_route()}}
+\item \href{#method-redirect}{\code{Dash$redirect()}}
 \item \href{#method-layout_get}{\code{Dash$layout_get()}}
 \item \href{#method-layout}{\code{Dash$layout()}}
 \item \href{#method-react_version_set}{\code{Dash$react_version_set()}}
@@ -231,11 +255,12 @@ be used to match any path element, rather than restricting (as by default) to
 a single path element. For example, it is possible to catch requests to multiple
 subpaths using a wildcard. For more information, see \link{Route}.}
 
-\item{\code{handler}}{Adds a handler function to the specified method and path.
+\item{\code{handler}}{Function. Adds a handler function to the specified method and path.
 For more information, see \link{Route}.}
 
 \item{\code{methods}}{Character. A string indicating the request method (in lower case,
-e.g. 'get', 'put', etc.), as used by \code{reqres}. For more information, see \link{Route}.}
+e.g. 'get', 'put', etc.), as used by \code{reqres}. The default is \code{get}.
+For more information, see \link{Route}.}
 }
 \if{html}{\out{</div>}}
 }
@@ -245,6 +270,16 @@ supports custom routing through plugins. While convenient, the plugin API
 providing this functionality is different from that provided by Flask, as
 used by Dash for Python. This method wraps the pluggable routing of \code{routr}
 routes in a manner that should feel slightly more idiomatic to Dash users.
+\subsection{Querying User-Defined Routes:}{
+
+It is possible to retrieve the list of user-defined routes by invoking the
+\code{get_data} method. For example, if your Dash application object is \code{app}, use
+\code{app$server$get_data("user-routes")}.
+
+If you wish to erase all user-defined routes without instantiating a new Dash
+application object, one option is to clear the routes manually:
+\code{app$server$set_data("user-routes", list())}.
+}
 }
 
 \subsection{Examples}{
@@ -252,12 +287,72 @@ routes in a manner that should feel slightly more idiomatic to Dash users.
 \preformatted{library(dash)
 app <- Dash$new()
 
-# A handler to serve 418 errors; see https://tools.ietf.org/html/rfc7168
-app$server_route("/teapot", function(request, response, keys, ...) {
-  response$status <- 418L
-  response$body('may be short and stout')
+# A handler to redirect requests with `307` status code (temporary redirects); 
+# for permanent redirects (`301`), see the `redirect` method described below
+# 
+# A simple single path-to-path redirect
+app$server_route('/getting-started', function(request, response, keys, ...) {
+  response$status <- 307L
+  response$set_header('Location', '/layout')
   TRUE
 })
+
+# Example of a parameterized redirect with a wildcard for subpaths
+app$server_route('/getting-started/*', function(request, response, keys, ...) {
+  response$status <- 307L
+  response$set_header('Location', '/layout')
+  TRUE
+})
+}
+\if{html}{\out{</div>}}
+
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-redirect"></a>}}
+\if{latex}{\out{\hypertarget{method-redirect}{}}}
+\subsection{Method \code{redirect()}}{
+Redirect a Dash application URL path
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Dash$redirect(old_path = NULL, new_path = NULL, methods = "get")}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{old_path}}{Character. Represents the URL path to redirect,
+comprised of strings, parameters (strings prefixed with :), and
+wildcards (*), separated by /. Wildcards can be used to match any
+path element, rather than restricting (as by default) to a single
+path element. For example, it is possible to catch requests to multiple
+subpaths using a wildcard. For more information, see \link{Route}.}
+
+\item{\code{new_path}}{Character. Same as \code{old_path}, but represents the
+new path which the client should load instead.}
+
+\item{\code{methods}}{Character. A string indicating the request method
+(in lower case, e.g. 'get', 'put', etc.), as used by \code{reqres}. The
+default is \code{get}. For more information, see \link{Route}.}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Details}{
+This is a convenience method to simplify adding redirects
+for your Dash application which automatically return a \code{301}
+HTTP status code and direct the client to load an alternate URL.
+}
+
+\subsection{Examples}{
+\if{html}{\out{<div class="r example copy">}}
+\preformatted{library(dash)
+app <- Dash$new()
+
+# example of a simple single path-to-path redirect
+app$redirect("/getting-started", "/layout")
+
+# example of a parameterized redirect using wildcards
+app$redirect("/getting-started/*", "/layout/*")
 }
 \if{html}{\out{</div>}}
 

--- a/tests/testthat/test-routes.R
+++ b/tests/testthat/test-routes.R
@@ -6,7 +6,7 @@ test_that("URLs are properly redirected with app$redirect", {
  app <- Dash$new()
 
  app$redirect("/foo", "/")
- app$redirect("/bar/*", "/")
+ app$redirect("/bar/*", "/*")
 
  app$layout(htmlDiv(
   "Hello world!"
@@ -63,7 +63,7 @@ test_that("temporary redirection of URLs is possible with app$server_route", {
 
  app$server_route("/qux/*", function(request, response, keys, ...) {
   response$status <- 307L
-  response$set_header("Location", "/")
+  response$set_header("Location", "/*")
   TRUE
  })
 

--- a/tests/testthat/test-routes.R
+++ b/tests/testthat/test-routes.R
@@ -45,7 +45,7 @@ test_that("URLs are properly redirected with app$redirect", {
 
  expect_equal(
    response_bar$headers$Location,
-   "/"
+   "/*"
  )
 
 })
@@ -104,7 +104,7 @@ test_that("temporary redirection of URLs is possible with app$server_route", {
 
  expect_equal(
    response_qux$headers$Location,
-   "/"
+   "/*"
  )
 
 })

--- a/tests/testthat/test-routes.R
+++ b/tests/testthat/test-routes.R
@@ -6,7 +6,7 @@ test_that("URLs are properly redirected with app$redirect", {
  app <- Dash$new()
 
  app$redirect("/foo", "/")
- app$redirect("/bar/*", "/*")
+ app$redirect("/bar/*", "/foo")
 
  app$layout(htmlDiv(
   "Hello world!"
@@ -45,7 +45,7 @@ test_that("URLs are properly redirected with app$redirect", {
 
  expect_equal(
    response_bar$headers$Location,
-   "/*"
+   "/foo"
  )
 
 })
@@ -63,7 +63,7 @@ test_that("temporary redirection of URLs is possible with app$server_route", {
 
  app$server_route("/qux/*", function(request, response, keys, ...) {
   response$status <- 307L
-  response$set_header("Location", "/*")
+  response$set_header("Location", "/foo")
   TRUE
  })
 
@@ -104,7 +104,7 @@ test_that("temporary redirection of URLs is possible with app$server_route", {
 
  expect_equal(
    response_qux$headers$Location,
-   "/*"
+   "/foo"
  )
 
 })

--- a/tests/testthat/test-routes.R
+++ b/tests/testthat/test-routes.R
@@ -1,0 +1,110 @@
+context("routes")
+
+test_that("URLs are properly redirected with app$redirect", {
+ library(dashHtmlComponents)
+
+ app <- Dash$new()
+
+ app$redirect("/foo", "/")
+ app$redirect("/bar/*", "/")
+
+ app$layout(htmlDiv(
+  "Hello world!"
+  )
+ )
+
+ request_foo <- fiery::fake_request(
+   "http://127.0.0.1:8050/foo"
+ )
+
+ request_bar <- fiery::fake_request(
+   "http://127.0.0.1:8050/bar/foo"
+ )
+
+ # start up Dash briefly to load the routes
+ app$run_server(block=FALSE)
+ app$server$stop()
+
+ response_foo <- app$server$test_request(request_foo)
+ response_bar <- app$server$test_request(request_bar)
+
+ expect_equal(
+   response_foo$status,
+   301L
+  )
+
+ expect_equal(
+   response_foo$headers$Location,
+   "/"
+ )
+
+ expect_equal(
+   response_bar$status,
+   301L
+  )
+
+ expect_equal(
+   response_bar$headers$Location,
+   "/"
+ )
+
+})
+
+test_that("temporary redirection of URLs is possible with app$server_route", {
+ library(dashHtmlComponents)
+
+ app <- Dash$new()
+
+ app$server_route("/baz", function(request, response, keys, ...) {
+  response$status <- 307L
+  response$set_header("Location", "/")
+  TRUE
+ })
+
+ app$server_route("/qux/*", function(request, response, keys, ...) {
+  response$status <- 307L
+  response$set_header("Location", "/")
+  TRUE
+ })
+
+ app$layout(htmlDiv(
+  "Hello world!"
+  )
+ )
+
+ request_baz <- fiery::fake_request(
+   "http://127.0.0.1:8050/baz"
+ )
+
+ request_qux <- fiery::fake_request(
+   "http://127.0.0.1:8050/qux/foo"
+ )
+
+ # start up Dash briefly to load the routes
+ app$run_server(block=FALSE)
+ app$server$stop()
+
+ response_baz <- app$server$test_request(request_baz)
+ response_qux <- app$server$test_request(request_qux)
+
+ expect_equal(
+   response_baz$status,
+   307L
+  )
+
+ expect_equal(
+   response_baz$headers$Location,
+   "/"
+ )
+
+ expect_equal(
+   response_qux$status,
+   307L
+  )
+
+ expect_equal(
+   response_qux$headers$Location,
+   "/"
+ )
+
+})

--- a/tests/testthat/test-routes.R
+++ b/tests/testthat/test-routes.R
@@ -7,6 +7,7 @@ test_that("URLs are properly redirected with app$redirect", {
 
  app$redirect("/foo", "/")
  app$redirect("/bar/*", "/foo")
+ app$redirect("/users/:user_id", function(keys) paste0("/accounts/", keys$user_id))
 
  app$layout(htmlDiv(
   "Hello world!"
@@ -21,12 +22,17 @@ test_that("URLs are properly redirected with app$redirect", {
    "http://127.0.0.1:8050/bar/foo"
  )
 
+ request_fn <- fiery::fake_request(
+   "http://127.0.0.1:8050/users/johndoe"
+ )
+
  # start up Dash briefly to load the routes
  app$run_server(block=FALSE)
  app$server$stop()
 
  response_foo <- app$server$test_request(request_foo)
  response_bar <- app$server$test_request(request_bar)
+ response_fn <- app$server$test_request(request_fn)
 
  expect_equal(
    response_foo$status,
@@ -36,7 +42,7 @@ test_that("URLs are properly redirected with app$redirect", {
  expect_equal(
    response_foo$headers$Location,
    "/"
- )
+  )
 
  expect_equal(
    response_bar$status,
@@ -46,7 +52,17 @@ test_that("URLs are properly redirected with app$redirect", {
  expect_equal(
    response_bar$headers$Location,
    "/foo"
- )
+  )
+
+ expect_equal(
+   response_fn$status,
+   301L
+  )
+
+ expect_equal(
+   response_fn$headers$Location,
+   "/accounts/johndoe"
+  )
 
 })
 


### PR DESCRIPTION
This PR proposes to address #131, in order that Dash for R users may be able to create and modify routes as is currently possible in Dash for Python, thanks to Flask's customizable routing. Fiery supports routing "plugins", but it can be complicated to use them, or modify routes that already exist (see below). Two new methods are proposed in Dash for R:

- `server_route`: this method registers a new URL rule, as described by its `methods`, `url` and `handler` function
- `redirect`: this method can be used to redirect a path (single, or parameterized/with wildcards) to another path, as the handler is specified internally and returns a `301` (Moved Permanently) status within the response

Since Dash for R lacks the support for decorator methods that Python provides, the `handler` argument allows matching a handler function with a URL to be routed. In brief, the `server_route` method registers the URL routing information via `self$server$set_data("user-routes")`. Upon invoking `app$run_server`, Dash checks whether any `user-routes` are defined; if one or more routes exists, a plugin is generated on the fly, to insert all the routes in the order they were defined. Finally, the plugin is attached to the running server object. This process is repeated when the server shuts down/is aborted and restarted. The routing information remains intact, as it was stored via `set_data`.

The proposed changes are a compromise between making the code succinct and continuing to take advantage of `routr` features, while making it easier for users to add/remove routes and find documentation for this feature generally.

-----

## Previous interface

```r
... #code specifying packages, layout, callbacks omitted

plugin <- list(
  on_attach = function(server) {
    router <- server$plugins$request_routr
    route <- routr::Route$new()
    redirect_getting_started <- function(request, response, keys, ...) {
      response$status <- 301L
      response$set_header('Location', '/layout')
      TRUE
    }
    redirect_state <- function(request, response, keys, ...) {
      response$status <- 301L
      response$set_header('Location', '/basic-callbacks')
      TRUE
    }
    route$add_handler('get', '/getting-started', redirect_getting_started)
    route$add_handler('get', '/getting-started-part-2', redirect_state)
    route$add_handler('get', '/state', redirect_state)
    router$add_route(route, "redirects")
  },
  name = 'redirect_urls',
  require = 'request_routr'
)

app$server$attach(plugin)
app$run_server()
```

## Proposed interface

```r
... #code specifying packages, layout, callbacks omitted

app$server_route("/getting-started", function(request, response, keys, ...) {
  response$status <- 301L
  response$set_header('Location', '/layout')
  TRUE
})

app$server_route("/getting-started-part-2", function(request, response, keys, ...) {
  response$status <- 301L
  response$set_header('Location', '/basic-callbacks')
  TRUE
})

app$server_route("/state", function(request, response, keys, ...) {
  response$status <- 301L
  response$set_header('Location', '/basic-callbacks')
  TRUE
})

app$run_server()
```

The `redirect` method provides a simplification of the above:

```r
app$redirect("/getting-started", "/layout")
app$redirect("/getting-started-part-2", "/basic-callbacks")
app$redirect("/state", "/basic-callbacks")
```

To do:
- [x] tests to validate adding routes, resulting HTTP status codes and redirects (as applicable)
- [x] provide sufficient documentation and simplify syntax, ensure example is provided
- [x] update CHANGELOG.md
- [x] allow developers to pass in a function when using `app$redirect` in lieu of a string for the `new_path` argument, which would be evaluated as a string within `app$redirect`'s internal handler