### PR TITLE
Provide support for script and stylesheet attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to `dash` will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Added
+- Support for setting attributes on `external_scripts` and `external_stylesheets`, and validation for the parameters passed (attributes are verified, and elements that are lists themselves must be named). [#226](https://github.com/plotly/dashR/pull/226)
+
 ## [0.7.1] - 2020-07-30
 ### Fixed
 - Fixes a minor bug in debug mode that prevented display of user-defined error messages when induced by invoking the `stop` function. [#220](https://github.com/plotly/dashR/pull/220).

--- a/R/dash.R
+++ b/R/dash.R
@@ -45,9 +45,13 @@ Dash <- R6::R6Class(
     #' @param requests_pathname_prefix Character. A prefix applied to request endpoints
     #' made by Dash's front-end. Environment variable is `DASH_REQUESTS_PATHNAME_PREFIX`.
     #' @param external_scripts List. An optional list of valid URLs from which
-    #' to serve JavaScript source for rendered pages.
+    #' to serve JavaScript source for rendered pages. Each entry can be a string (the URL)
+    #' or a list with `src` (the URL) and optionally other `<script>` tag attributes such
+    #' as `integrity` and `crossorigin`.
     #' @param external_stylesheets List. An optional list of valid URLs from which
-    #' to serve CSS for rendered pages.
+    #' to serve CSS for rendered pages. Each entry can be a string (the URL) or a list
+    #' with `href` (the URL) and optionally other `<link>` tag attributes such as 
+    #' `rel`, `integrity` and `crossorigin`.
     #' @param compress Logical. Whether to  try to compress files and data served by Fiery.
     #' By default, `brotli` is attempted first, then `gzip`, then the `deflate` algorithm,
     #' before falling back to `identity`.
@@ -1578,7 +1582,7 @@ Dash <- R6::R6Class(
 
       # collect CSS assets from dependencies
       if (!(is.null(private$asset_map$css))) {
-        css_assets <- generate_css_dist_html(href = paste0(private$assets_url_path, names(private$asset_map$css)),
+        css_assets <- generate_css_dist_html(tagdata = paste0(private$assets_url_path, names(private$asset_map$css)),
                                              local = TRUE,
                                              local_path = private$asset_map$css,
                                              prefix = self$config$requests_pathname_prefix)
@@ -1596,7 +1600,7 @@ Dash <- R6::R6Class(
       # collect JS assets from dependencies
       #
       if (!(is.null(private$asset_map$scripts))) {
-        scripts_assets <- generate_js_dist_html(href = paste0(private$assets_url_path, names(private$asset_map$scripts)),
+        scripts_assets <- generate_js_dist_html(tagdata = paste0(private$assets_url_path, names(private$asset_map$scripts)),
                                                 local = TRUE,
                                                 local_path = private$asset_map$scripts,
                                                 prefix = self$config$requests_pathname_prefix)

--- a/R/dash.R
+++ b/R/dash.R
@@ -108,6 +108,9 @@ Dash <- R6::R6Class(
       self$config$show_undo_redo <- show_undo_redo
       self$config$update_title <- update_title
 
+      # ensure attributes are valid, if using a list within a list, elements are all named
+      assertValidExternals(scripts = external_scripts, stylesheets = external_stylesheets)
+
       # ------------------------------------------------------------
       # Initialize a route stack and register a static resource route
       # ------------------------------------------------------------

--- a/R/utils.R
+++ b/R/utils.R
@@ -175,7 +175,7 @@ render_dependencies <- function(dependencies, local = TRUE, prefix=NULL) {
         html <- generate_js_dist_html(tagdata = dep[["script"]], as_is = TRUE)
       }
     } else if (!(is_local) & "stylesheet" %in% names(dep) & src == "href") {
-      html <- generate_css_dist_html(href = paste(dep[["src"]][["href"]],
+      html <- generate_css_dist_html(tagdata = paste(dep[["src"]][["href"]],
                                                   dep[["stylesheet"]],
                                                   sep="/"),
                                      local = FALSE)
@@ -613,9 +613,9 @@ generate_js_dist_html <- function(tagdata,
         tagdata,
         perl=TRUE)) || as_is) {
             if (is.list(tagdata))
-                glue::glue('<script ', glue::glue_collapse(glue::glue('{attribs}="{tagdata}"'), sep=" "), ' ></script>')
+                glue::glue('<script ', glue::glue_collapse(glue::glue('{attribs}="{tagdata}"'), sep=" "), '></script>')
             else
-                glue::glue('<script ', glue::glue('src="{tagdata}"'), ' ></script>')
+                glue::glue('<script ', glue::glue('src="{tagdata}"'), '></script>')
         }
     else
       stop(sprintf("Invalid URL supplied. Please check the syntax used for this parameter."), call. = FALSE)
@@ -627,7 +627,7 @@ generate_js_dist_html <- function(tagdata,
       href <- tagdata
     href <- sub("^/", "", href)
     modified <- as.integer(file.mtime(local_path))
-    glue::glue('<script src="{prefix}{href}?m={modified}" ></script>')
+    glue::glue('<script src="{prefix}{href}?m={modified}"></script>')
   }
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -635,22 +635,40 @@ assertValidExternals <- function(scripts, stylesheets) {
     
     for (item in scripts) {
       if (is.list(item)) {
+        if (!"src" %in% names(item) || !(any(grepl("^(?:http(s)?:\\/\\/)?[\\w.-]+(?:\\.[\\w\\.-]+)+[\\w\\-\\._~:/?#[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$",
+            item,
+            perl=TRUE))))
+          stop("A valid URL must be included with every entry in external_scripts. Please sure no 'src' entries are missing or malformed.", call. = FALSE)
         if (any(names(item) == ""))
           stop("Please verify that all attributes are named elements when specifying URLs for scripts and stylesheets.", call. = FALSE)
         script_attributes <- c(script_attributes, names(item))
       }
-      else 
+      else {
+        if (!grepl("^(?:http(s)?:\\/\\/)?[\\w.-]+(?:\\.[\\w\\.-]+)+[\\w\\-\\._~:/?#[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$",
+            item,
+            perl=TRUE))
+            stop("A valid URL must be included with every entry in external_scripts. Please sure no 'src' entries are missing or malformed.", call. = FALSE)
         script_attributes <- c(script_attributes, character(0))
+      }
     }
-    
+
     for (item in stylesheets) {
       if (is.list(item)) {
+        if (!"href" %in% names(item) || !(any(grepl("^(?:http(s)?:\\/\\/)?[\\w.-]+(?:\\.[\\w\\.-]+)+[\\w\\-\\._~:/?#[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$",
+            item,
+            perl=TRUE))))
+          stop("A valid URL must be included with every entry in external_stylesheets. Please sure no 'href' entries are missing or malformed.", call. = FALSE)
         if (any(names(item) == ""))
           stop("Please verify that all attributes are named elements when specifying URLs for scripts and stylesheets.", call. = FALSE)
         stylesheet_attributes <- c(stylesheet_attributes, names(item))
       }
-      else 
+      else {
+        if (!grepl("^(?:http(s)?:\\/\\/)?[\\w.-]+(?:\\.[\\w\\.-]+)+[\\w\\-\\._~:/?#[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$",
+            item,
+            perl=TRUE))
+            stop("A valid URL must be included with every entry in external_stylesheets. Please sure no 'href' entries are missing or malformed.", call. = FALSE)
         stylesheet_attributes <- c(stylesheet_attributes, character(0))
+      }
     }
     
     invalid_script_attributes <- setdiff(script_attributes, allowed_js_attribs)

--- a/man/Dash.Rd
+++ b/man/Dash.Rd
@@ -174,10 +174,14 @@ Environment variable is \code{DASH_ROUTES_PATHNAME_PREFIX}.}
 made by Dash's front-end. Environment variable is \code{DASH_REQUESTS_PATHNAME_PREFIX}.}
 
 \item{\code{external_scripts}}{List. An optional list of valid URLs from which
-to serve JavaScript source for rendered pages.}
+to serve JavaScript source for rendered pages. Each entry can be a string (the URL)
+or a list with \code{src} (the URL) and optionally other \verb{<script>} tag attributes such
+as \code{integrity} and \code{crossorigin}.}
 
 \item{\code{external_stylesheets}}{List. An optional list of valid URLs from which
-to serve CSS for rendered pages.}
+to serve CSS for rendered pages. Each entry can be a string (the URL) or a list
+with \code{href} (the URL) and optionally other \verb{<link>} tag attributes such as
+\code{rel}, \code{integrity} and \code{crossorigin}.}
 
 \item{\code{compress}}{Logical. Whether to  try to compress files and data served by Fiery.
 By default, \code{brotli} is attempted first, then \code{gzip}, then the \code{deflate} algorithm,

--- a/tests/testthat/test-attributes.R
+++ b/tests/testthat/test-attributes.R
@@ -98,9 +98,8 @@ test_that("stylesheets can be added with or without attributes", {
   )
 
   expect_equal(
-    script_hrefs,
-    c("<script src=\"https://unpkg.com/react@16.8.6\"></script>\n<script src=\"https://unpkg.com/react-dom@16.8.6\"></script>\n<script src=\"https://unpkg.com/prop-types@15.7.2\"></script>\n<script src=\"https://unpkg.com/@babel/polyfill@7.7.0\"></script>\n<script src=\"/_dash-component-suites/dash_html_components/dash_html_components.v1_0_3m1598593100.min.js?v=1.0.3&m=1598593100\"></script>\n<script src=\"https://unpkg.com/dash-renderer@1.6.0\"></script>",
-      "<script src=\"https://www.google-analytics.com/analytics.js\"></script>", 
+    script_hrefs[2:4],
+      c("<script src=\"https://www.google-analytics.com/analytics.js\"></script>", 
       "<script src=\"https://cdn.polyfill.io/v2/polyfill.min.js\"></script>", 
       "<script src=\"https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.10/lodash.core.js\" integrity=\"sha256-Qqd/EfdABZUcAxjOkMi8eGEivtdTkh3b65xCZL4qAQA=\" crossorigin=\"anonymous\"></script>"
     )

--- a/tests/testthat/test-attributes.R
+++ b/tests/testthat/test-attributes.R
@@ -11,7 +11,7 @@ test_that("stylesheets can be added with or without attributes", {
                                              hreflang="en-us")
                                            ),
                   external_scripts = list(
-                    "https://www.google-analytics.com/analytics.js",
+                    src="https://www.google-analytics.com/analytics.js",
                     list(
                       src = "https://cdn.polyfill.io/v2/polyfill.min.js"
                     ),
@@ -55,9 +55,60 @@ test_that("stylesheets can be added with or without attributes", {
     )
   )
 
+  app <- Dash$new(serve_locally=FALSE, external_stylesheets = list(
+                                           list(
+                                             href="https://codepen.io/chriddyp/pen/bWLwgP.css",
+                                             hreflang="en-us")
+                                           ),
+                  external_scripts = list(
+                    src="https://www.google-analytics.com/analytics.js",
+                    list(
+                      src = "https://cdn.polyfill.io/v2/polyfill.min.js"
+                    ),
+                    list(
+                      src = "https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.10/lodash.core.js",
+                      integrity = "sha256-Qqd/EfdABZUcAxjOkMi8eGEivtdTkh3b65xCZL4qAQA=",
+                      crossorigin = "anonymous"
+                    )
+                  )
+          )
+  
+  app$layout(htmlDiv(
+    "Hello world!"
+  )
+  )
+  
+  request_with_attributes <- fiery::fake_request(
+    "http://127.0.0.1:8050"
+  )
+  
+  # start up Dash briefly to generate the index
+  app$run_server(block=FALSE)
+  app$server$stop()
+  
+  response_with_attributes <- app$server$test_request(request_with_attributes)
+
+  tags_by_line <- lapply(strsplit(response_with_attributes$body, "\n "), function(x) trimws(x))[[1]]
+  stylesheet_hrefs <- grep(stylesheet_pattern, tags_by_line, value = TRUE)
+  script_hrefs <- grep(script_pattern, tags_by_line, value = TRUE)
+    
+  expect_equal(
+    stylesheet_hrefs,
+    "<link href=\"https://codepen.io/chriddyp/pen/bWLwgP.css\" hreflang=\"en-us\" rel=\"stylesheet\">"
+  )
+
+  expect_equal(
+    script_hrefs,
+    c("<script src=\"https://unpkg.com/react@16.8.6\"></script>\n<script src=\"https://unpkg.com/react-dom@16.8.6\"></script>\n<script src=\"https://unpkg.com/prop-types@15.7.2\"></script>\n<script src=\"https://unpkg.com/@babel/polyfill@7.7.0\"></script>\n<script src=\"/_dash-component-suites/dash_html_components/dash_html_components.v1_0_3m1598593100.min.js?v=1.0.3&m=1598593100\"></script>\n<script src=\"https://unpkg.com/dash-renderer@1.6.0\"></script>",
+      "<script src=\"https://www.google-analytics.com/analytics.js\"></script>", 
+      "<script src=\"https://cdn.polyfill.io/v2/polyfill.min.js\"></script>", 
+      "<script src=\"https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.10/lodash.core.js\" integrity=\"sha256-Qqd/EfdABZUcAxjOkMi8eGEivtdTkh3b65xCZL4qAQA=\" crossorigin=\"anonymous\"></script>"
+    )
+  )
+
 })
 
-test_that("invalid attributes trigger a warning", {
+test_that("invalid attributes trigger an error", {
   library(dashHtmlComponents)
 
   external_stylesheets <- list(
@@ -67,7 +118,7 @@ test_that("invalid attributes trigger a warning", {
                               bar="moredata"
                               )
                             )
-                                            
+
   external_scripts <- list(
                         "https://www.google-analytics.com/analytics.js",
                         list(
@@ -101,3 +152,95 @@ test_that("not passing named attributes triggers an error", {
     "Please verify that all attributes are named elements when specifying URLs for scripts and stylesheets.")
 })
 
+test_that("stylesheet can be passed as a simple list", {
+  library(dashHtmlComponents)
+  stylesheet_pattern <- '^.*<link href="(https.*)">.*$'
+  script_pattern <- '^.*<script src="(https.*)">.*$'
+
+  app <- Dash$new(external_stylesheets = list("https://codepen.io/chriddyp/pen/bWLwgP.css"))
+
+  app$layout(htmlDiv(
+    "Hello world!"
+  )
+  )
+
+  request_with_attributes <- fiery::fake_request(
+    "http://127.0.0.1:8050"
+  )
+
+  # start up Dash briefly to generate the index
+  app$run_server(block=FALSE)
+  app$server$stop()
+
+  response_with_attributes <- app$server$test_request(request_with_attributes)
+
+  tags_by_line <- lapply(strsplit(response_with_attributes$body, "\n "), function(x) trimws(x))[[1]]
+  stylesheet_hrefs <- grep(stylesheet_pattern, tags_by_line, value = TRUE)
+
+  expect_equal(
+    stylesheet_hrefs,
+    "<link href=\"https://codepen.io/chriddyp/pen/bWLwgP.css\" rel=\"stylesheet\">"
+  )
+})
+
+test_that("not passing named attributes triggers an error", {
+  library(dashHtmlComponents)
+
+  external_stylesheets = list(
+                            list(
+                              href="https://codepen.io/chriddyp/pen/bWLwgP.css",
+                              "somedata"
+                              )
+                            )
+
+  expect_error(app <- Dash$new(external_stylesheets=external_stylesheets),
+    "Please verify that all attributes are named elements when specifying URLs for scripts and stylesheets.")
+  expect_error(app <- Dash$new(serve_locally=FALSE, external_stylesheets=external_stylesheets),
+    "Please verify that all attributes are named elements when specifying URLs for scripts and stylesheets.")
+})
+
+test_that("passing a list with no href/src fails", {
+  library(dashHtmlComponents)
+  stylesheet_pattern <- '^.*<link href="(https.*)">.*$'
+  script_pattern <- '^.*<script src="(https.*)">.*$'
+      
+  expect_error(app <- Dash$new(external_stylesheets = list(
+                      href="https://codepen.io/chriddyp/pen/bWLwgP.css",
+                            list(
+                              integrity="somedata",
+                              crossorigin="moredata"
+                              )
+                            )
+                  ),
+                  "A valid URL must be included with every entry in external_stylesheets. Please sure no 'href' entries are missing or malformed.")
+
+  expect_error(app <- Dash$new(serve_locally=FALSE, external_stylesheets = list(
+                      href="https://codepen.io/chriddyp/pen/bWLwgP.css",
+                            list(
+                              integrity="somedata",
+                              crossorigin="moredata"
+                              )
+                            )
+                  ),
+                  "A valid URL must be included with every entry in external_stylesheets. Please sure no 'href' entries are missing or malformed.")
+
+  expect_error(app <- Dash$new(external_scripts = list(
+                      href="https://rivetscriptemporium.com/test.js",
+                            list(
+                              integrity="somedata",
+                              crossorigin="moredata"
+                              )
+                            )
+                  ),
+                  "A valid URL must be included with every entry in external_scripts. Please sure no 'src' entries are missing or malformed.")
+
+  expect_error(app <- Dash$new(serve_locally=FALSE, external_scripts = list(
+                      href="https://rivetscriptemporium.com/test.js",
+                            list(
+                              integrity="somedata",
+                              crossorigin="moredata"
+                              )
+                            )
+                  ),
+                  "A valid URL must be included with every entry in external_scripts. Please sure no 'src' entries are missing or malformed.")
+})

--- a/tests/testthat/test-attributes.R
+++ b/tests/testthat/test-attributes.R
@@ -1,0 +1,103 @@
+context("attributes")
+
+test_that("stylesheets can be added with or without attributes", {
+  library(dashHtmlComponents)
+  stylesheet_pattern <- '^.*<link href="(https.*)">.*$'
+  script_pattern <- '^.*<script src="(https.*)">.*$'
+      
+  app <- Dash$new(external_stylesheets = list(
+                                           list(
+                                             href="https://codepen.io/chriddyp/pen/bWLwgP.css",
+                                             hreflang="en-us")
+                                           ),
+                  external_scripts = list(
+                    "https://www.google-analytics.com/analytics.js",
+                    list(
+                      src = "https://cdn.polyfill.io/v2/polyfill.min.js"
+                    ),
+                    list(
+                      src = "https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.10/lodash.core.js",
+                      integrity = "sha256-Qqd/EfdABZUcAxjOkMi8eGEivtdTkh3b65xCZL4qAQA=",
+                      crossorigin = "anonymous"
+                    )
+                  )
+          )
+  
+  app$layout(htmlDiv(
+    "Hello world!"
+  )
+  )
+  
+  request_with_attributes <- fiery::fake_request(
+    "http://127.0.0.1:8050"
+  )
+  
+  # start up Dash briefly to generate the index
+  app$run_server(block=FALSE)
+  app$server$stop()
+  
+  response_with_attributes <- app$server$test_request(request_with_attributes)
+
+  tags_by_line <- lapply(strsplit(response_with_attributes$body, "\n "), function(x) trimws(x))[[1]]
+  stylesheet_hrefs <- grep(stylesheet_pattern, tags_by_line, value = TRUE)
+  script_hrefs <- grep(script_pattern, tags_by_line, value = TRUE)
+    
+  expect_equal(
+    stylesheet_hrefs,
+    "<link href=\"https://codepen.io/chriddyp/pen/bWLwgP.css\" hreflang=\"en-us\" rel=\"stylesheet\">"
+  )
+  
+  expect_equal(
+    script_hrefs,
+    c("<script src=\"https://www.google-analytics.com/analytics.js\"></script>", 
+      "<script src=\"https://cdn.polyfill.io/v2/polyfill.min.js\"></script>", 
+      "<script src=\"https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.10/lodash.core.js\" integrity=\"sha256-Qqd/EfdABZUcAxjOkMi8eGEivtdTkh3b65xCZL4qAQA=\" crossorigin=\"anonymous\"></script>"
+    )
+  )
+
+})
+
+test_that("invalid attributes trigger a warning", {
+  library(dashHtmlComponents)
+
+  external_stylesheets <- list(
+                            list(
+                              href="https://codepen.io/chriddyp/pen/bWLwgP.css",
+                              foo="somedata",
+                              bar="moredata"
+                              )
+                            )
+                                            
+  external_scripts <- list(
+                        "https://www.google-analytics.com/analytics.js",
+                        list(
+                          src = "https://cdn.polyfill.io/v2/polyfill.min.js"
+                        ),
+                        list(
+                          src = "https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.10/lodash.core.js",
+                          integrity = "sha256-Qqd/EfdABZUcAxjOkMi8eGEivtdTkh3b65xCZL4qAQA=",
+                          baz = "anonymous"
+                        )
+                      )
+
+  expect_error(dash:::assertValidExternals(external_scripts, external_stylesheets), 
+    "The following script or stylesheet attributes are invalid: baz, foo, bar.")
+})
+
+test_that("not passing named attributes triggers an error", {
+  library(dashHtmlComponents)
+
+  external_stylesheets <- list(
+                            list(
+                              href="https://codepen.io/chriddyp/pen/bWLwgP.css",
+                              foo="somedata",
+                              "moredata"
+                              )
+                            )
+                                            
+  external_scripts <- list()
+
+  expect_error(dash:::assertValidExternals(external_scripts, external_stylesheets), 
+    "Please verify that all attributes are named elements when specifying URLs for scripts and stylesheets.")
+})
+


### PR DESCRIPTION
This PR proposes to address #98; a brief summary of changes:
- provides parity with the current Dash for Python interface, allowing either a list of strings or a list of lists to be passed -- the latter providing access to setting attributes for a given URL
- validates attributes for both `<script>` and `<link>` tags; if an invalid attributes are passed, Dash for R will present a helpful error message identifying which attributes should be omitted/corrected
- replaces `sprintf` with `glue`, which is slightly easier to read and as performant

Proposed syntax:

```r
app <- Dash$new(external_stylesheets = list(
                                         list(
                                           href="https://codepen.io/chriddyp/pen/bWLwgP.css",
                                           hreflang="en-us")
                                         )
)
```

...and a sample result:

![image](https://user-images.githubusercontent.com/9809798/91313579-8cf7bf00-e783-11ea-8f23-90a386373ca4.png)
