### PR TITLE
Remove references to Docker Hub context within CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,4 @@ workflows:
   version: 2
   build:
     jobs:
-      - "test":
-          context:
-            - dash-docker-hub
+      - "test"


### PR DESCRIPTION
This PR aims to address "unauthorized" CircleCI errors related to CI builds triggered by updates from community contributors, who do not have access to our organization's context.

@alexcjohnson @Marc-Andre-Rivet 