### PR TITLE
Fix suppress_callback_exceptions config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,14 +36,10 @@ jobs:
       - run:
           name: ⚙️  Integration tests
           command: |
-            curl --proto '=https' --tlsv1.2 -sSf -o rust-init.sh https://sh.rustup.rs
-            chmod ugo+x rust-init.sh
-            ./rust-init.sh -y
             python -m venv venv
             . venv/bin/activate
+            pip install --upgrade pip
             git clone --depth 1 https://github.com/plotly/dash.git dash-main
-            export PATH=$PATH:/home/circleci/.local/bin/:/home/circleci/.cargo/bin
-            export RUSTC_BOOTSTRAP=1
             cd dash-main && pip install -e .[dev,testing] --progress-bar off && cd ..
             cd dash-main/\@plotly/dash-generator-test-component-nested && npm ci && npm run build && sudo R CMD INSTALL . && cd ../../..
             cd dash-main/\@plotly/dash-generator-test-component-standard && npm ci && npm run build && sudo R CMD INSTALL . && cd ../../..

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Minor fix for favicon issue continued from [#240](https://github.com/plotly/dashr/pull/240) (for more details, see [#243](https://github.com/plotly/dashR/pull/243#issuecomment-842813526)).
+- Minor fix to enable `suppress_callback_exceptions` configuration option when creating a Dash app. [#268](https://github.com/plotly/dashr/pull/268)
+
 
 ## [0.9.1] - 2020-11-16
 ### Fixed

--- a/R/dash.R
+++ b/R/dash.R
@@ -107,6 +107,7 @@ Dash <- R6::R6Class(
       self$config$external_stylesheets <- external_stylesheets
       self$config$show_undo_redo <- show_undo_redo
       self$config$update_title <- update_title
+      self$config$suppress_callback_exceptions <- suppress_callback_exceptions
 
       # ensure attributes are valid, if using a list within a list, elements are all named
       assertValidExternals(scripts = external_scripts, stylesheets = external_stylesheets)


### PR DESCRIPTION
This PR fixes the following issue by setting the `suppress_callback_exceptions` key for the `config` object sent to the front-end for layout validation.

> The Gotchas section talks about validation of callbacks and how you can use `suppress_callback_exceptions` to not perform this validation, but when I tried this out it didn't work as expected. In the following app, the javascript console gives an error and tells me to use `suppress_callback_exceptions` even though it is used:


```
library(dash)

app <- Dash$new(suppress_callback_exceptions = TRUE)
app$layout(dashHtmlComponents::htmlDiv("test"))
app$callback(
  output("foo", "children"),
  list(input("bar", "value")),
  function(test) {
    test
  }
)
app$run_server()
```